### PR TITLE
Fix d3_array for older browsers

### DIFF
--- a/src/core/array.js
+++ b/src/core/array.js
@@ -1,34 +1,18 @@
-function d3_array(psuedoarray) {
+var d3_arrayArguments = d3_arraySlice, // conversion for arguments
+    d3_arrayNodes = d3_arraySlice; // conversion for NodeLists
+
+function d3_arraySlow(psuedoarray) {
+  var i = -1, n = psuedoarray.length, array = [];
+  while (++i < n) array.push(psuedoarray[i]);
+  return array;
+}
+
+function d3_arraySlice(psuedoarray) {
   return Array.prototype.slice.call(psuedoarray);
 }
 
-// Adapted from Sizzle.js:
-//
-// Perform a simple check to determine if the browser is capable of
-// converting a NodeList to an array using builtin methods.
-// Also verifies that the returned array holds DOM nodes
-// (which is not the case in the Blackberry browser)
 try {
-  Array.prototype.slice.call(document.documentElement.childNodes, 0)[0].nodeType;
-// Provide a fallback method if it does not work
+  d3_arrayNodes(document.documentElement.childNodes)[0].nodeType;
 } catch(e) {
-  d3_array = function(array) {
-    var i = 0,
-      ret = [];
-
-    if (toString.call(array) === "[object Array]") {
-      Array.prototype.push.apply(ret, array);
-    } else {
-      if (typeof array.length === "number") {
-        for (var l = array.length; i < l; i++) {
-          ret.push(array[i]);
-        }
-      } else {
-        for (; array[i]; i++) {
-          ret.push(array[i]);
-        }
-      }
-    }
-    return ret;
-  };
+  d3_arrayNodes = d3_arraySlow;
 }

--- a/src/core/call.js
+++ b/src/core/call.js
@@ -1,5 +1,5 @@
 function d3_call(callback, var_args) {
-  var_args = d3_array(arguments);
+  var_args = d3_arrayArguments(arguments);
   var_args[0] = this;
   callback.apply(this, var_args);
   return this;

--- a/src/core/selection.js
+++ b/src/core/selection.js
@@ -1,5 +1,5 @@
 var d3_select = function(s, n) { return n.querySelector(s); },
-    d3_selectAll = function(s, n) { return d3_array(n.querySelectorAll(s)); };
+    d3_selectAll = function(s, n) { return d3_arrayNodes(n.querySelectorAll(s)); };
 
 // Use Sizzle, if available.
 if (typeof Sizzle == "function") {
@@ -20,7 +20,7 @@ d3.select = function(selector) {
 d3.selectAll = function(selector) {
   return typeof selector == "string"
       ? d3_root.selectAll(selector)
-      : d3_selection([d3_array(selector)]); // assume node[]
+      : d3_selection([d3_arrayNodes(selector)]); // assume node[]
 };
 
 function d3_selection(groups) {


### PR DESCRIPTION
This uses the code from Sizzle.js as suggested in issue #42. It seems slightly annoying to rely on `document.documentElement.childNodes` being available, but I guess it's the best way to get hold of a `NodeList`.

I noticed another use of `Array.prototype.slice` in `src/core/ease.js`, should that be updated to use `d3_array`?
