### PR TITLE
Fix voronoi example for IE9

### DIFF
--- a/ex/voronoi.css
+++ b/ex/voronoi.css
@@ -1,5 +1,6 @@
 svg {
   border: solid 1px #666;
+  overflow: hidden;
 }
 
 path {


### PR DESCRIPTION
All the other examples worked great in IE9. The voronoi example filled the entire page so `overflow: hidden` was needed to fix it.
