### PR TITLE
Default filename `index.html` for examples server.

### DIFF
--- a/examples/__main__.py
+++ b/examples/__main__.py
@@ -8,11 +8,11 @@ tornado.options.define("port", default=8888, type=int)
 
 if __name__ == "__main__":
   tornado.options.parse_command_line()
-  application = tornado.web.Application([], **{
-    "static_path": ".",
-    "static_url_prefix": "/"
-  })
+  application = tornado.web.Application([
+    (r"/(.*)", tornado.web.StaticFileHandler,
+      {"path": ".", "default_filename": "index.html"}),
+  ])
   http_server = tornado.httpserver.HTTPServer(application)
   http_server.listen(tornado.options.options.port)
-  print "http://localhost:%d/examples/index.html" % tornado.options.options.port
+  print "http://localhost:%d/examples/" % tornado.options.options.port
   tornado.ioloop.IOLoop.instance().start()


### PR DESCRIPTION
Mostly cosmetic :-) Just allows `/examples/` to be used instead of `/examples/index.html` for example.
