### PR TITLE
Small tweak.  Looks like d3_functor was replaced with d3.functor

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -2903,13 +2903,13 @@ d3.svg.diagonal = function() {
 
   diagonal.source = function(x) {
     if (!arguments.length) return source;
-    source = d3_functor(x);
+    source = d3.functor(x);
     return diagonal;
   };
 
   diagonal.target = function(x) {
     if (!arguments.length) return target;
-    target = d3_functor(x);
+    target = d3.functor(x);
     return diagonal;
   };
 

--- a/src/svg/diagonal.js
+++ b/src/svg/diagonal.js
@@ -14,13 +14,13 @@ d3.svg.diagonal = function() {
 
   diagonal.source = function(x) {
     if (!arguments.length) return source;
-    source = d3_functor(x);
+    source = d3.functor(x);
     return diagonal;
   };
 
   diagonal.target = function(x) {
     if (!arguments.length) return target;
-    target = d3_functor(x);
+    target = d3.functor(x);
     return diagonal;
   };
 


### PR DESCRIPTION
update diagonals, use d3.functor instead of the removed d3_functor function
