### PR TITLE
Updated data operator to better handle a join function which returns iden

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -1274,6 +1274,7 @@ function d3_selection(groups) {
 
       if (join) {
         var nodeByKey = {},
+ 	    nodes,
             keys = [],
             key,
             j = groupData.length;
@@ -1281,29 +1282,33 @@ function d3_selection(groups) {
         for (i = 0; i < n; i++) {
           key = join.call(node = group[i], node.__data__, i);
           if (key in nodeByKey) {
-            exitNodes[j++] = group[i]; // duplicate key
+	      nodeByKey[key].push(node);
           } else {
-            nodeByKey[key] = node;
+            nodeByKey[key] = [node];
           }
           keys.push(key);
         }
 
         for (i = 0; i < m; i++) {
-          node = nodeByKey[key = join.call(groupData, nodeData = groupData[i], i)];
-          if (node) {
+          nodes = nodeByKey[key = join.call(groupData, nodeData = groupData[i], i)];
+          if (nodes && (node=nodes.pop())) {
             node.__data__ = nodeData;
             updateNodes[i] = node;
             enterNodes[i] = exitNodes[i] = null;
+	    if (nodes.length==0)
+	      delete nodeByKey[key];
           } else {
             enterNodes[i] = d3_selection_enterNode(nodeData);
             updateNodes[i] = exitNodes[i] = null;
           }
-          delete nodeByKey[key];
         }
 
         for (i = 0; i < n; i++) {
-          if (keys[i] in nodeByKey) {
+          if (nodes=nodeByKey[keys[i]]){
+	    nodes.pop();
             exitNodes[i] = group[i];
+	    if (nodes.length==0)
+               delete nodeByKey[keys[i]];
           }
         }
       } else {


### PR DESCRIPTION
Updated data operator to better handle a join function which returns identical
values for multiple members of the data array.

For example, if a data array/join function is assigned such that the key value
"A" is returned 3 times, initially we would expect to see 3 corresponding
values in the returned entering selection -- as before.  However, if we again
pass the same data array/join function, we would expect to see no values in the
entering or exiting selections since the data and join are identical to what is
already in place.  However, the previous implementation would show values
exiting.  With this modification, if a given key is returned by the join
function n times, while the previous array had n0 occurrences of the same key,
then n0 corresponding entries will go in the updating selection, and n-n0 will
go to the entering or exiting selection depending on whether duplicates were
added or removed.
