### PR TITLE
fix minor errors

### DIFF
--- a/d3.chart.js
+++ b/d3.chart.js
@@ -981,4 +981,4 @@ function d3_chart_qqX(d) {
 function d3_chart_qqY(d) {
   return d.y;
 }
-})()
+})();

--- a/d3.csv.js
+++ b/d3.csv.js
@@ -89,4 +89,4 @@ function d3_csv_formatValue(text) {
       ? "\"" + text.replace(/\"/g, "\"\"") + "\""
       : text;
 }
-})()
+})();

--- a/d3.geo.js
+++ b/d3.geo.js
@@ -563,4 +563,4 @@ function d3_geo_boundsPolygon(o, f) {
     f.apply(null, a[i]);
   }
 }
-})()
+})();

--- a/d3.geom.js
+++ b/d3.geom.js
@@ -825,4 +825,4 @@ function d3_geom_quadtreePoint(p) {
     y: p[1]
   };
 }
-})()
+})();

--- a/d3.js
+++ b/d3.js
@@ -2248,7 +2248,7 @@ function d3_scale_linearNice(dx) {
   dx = Math.pow(10, Math.round(Math.log(dx) / Math.LN10) - 1);
   return {
     floor: function(x) { return Math.floor(x / dx) * dx; },
-    ceil: function(x) { return Math.ceil(x / dx) * dx; },
+    ceil: function(x) { return Math.ceil(x / dx) * dx; }
   };
 }
 function d3_scale_bilinear(domain, range, uninterpolate, interpolate) {
@@ -3421,4 +3421,4 @@ d3.svg.symbolTypes = d3.keys(d3_svg_symbols);
 
 var d3_svg_symbolSqrt3 = Math.sqrt(3),
     d3_svg_symbolTan30 = Math.tan(30 * Math.PI / 180);
-})()
+})();

--- a/d3.layout.js
+++ b/d3.layout.js
@@ -715,7 +715,7 @@ d3.layout.stack = function() {
   };
 
   return stack;
-}
+};
 
 function d3_layout_stackX(d) {
   return d.x;
@@ -1048,7 +1048,7 @@ d3.layout.hierarchy = function() {
   };
 
   return hierarchy;
-}
+};
 
 // A method assignment helper for hierarchy subclasses.
 function d3_layout_hierarchyRebind(object, hierarchy) {
@@ -1760,4 +1760,4 @@ d3.layout.treemap = function() {
 
   return d3_layout_hierarchyRebind(treemap, hierarchy);
 };
-})()
+})();

--- a/d3.time.js
+++ b/d3.time.js
@@ -310,4 +310,4 @@ function d3_time_zone(d) {
       zm = Math.abs(z) % 60;
   return zs + d3_time_zfill2(zh) + d3_time_zfill2(zm);
 }
-})()
+})();


### PR DESCRIPTION
I'm working with a system that concatenates all the JS into one file, and it doesn't deal well with the minor syntax issues in this file. 

In particular, the lack of ';' means that each anonymous function trys to call the next:

(...d3.js...)()
(...d3.layout.js...)()

putting semicolons at the end makes JS a lot happier.

The other minor change is a trailing-comma fix that would blow up explorer - I know there's know way you'd support old explorerers, but JS compilers/minimizers balk at the trailing comma...
