### PR TITLE
Patch to make JS minification work

### DIFF
--- a/lib/uglifyjs/bin/uglifyjs
+++ b/lib/uglifyjs/bin/uglifyjs
@@ -3,7 +3,7 @@
 
 global.sys = require(/^v0\.[012]/.test(process.version) ? "sys" : "util");
 var fs = require("fs");
-var uglify = require("../../UglifyJS"), // symlink ~/.node_libraries/uglify-js.js to ../uglify-js.js
+var uglify = require("../index.js"),
     jsp = uglify.parser,
     pro = uglify.uglify;
 


### PR DESCRIPTION
I installed node-0.4.8 but was still having trouble building minified versions of D3.js:

```
Error: Cannot find module '../../UglifyJS'
```

This patch changes the relative include inside of lib/uglifyjs so compiling D3 "just works" with node as the only pre-requisite.
