### PR TITLE
Removing trailing commas inside object

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -2252,7 +2252,7 @@ function d3_scale_linearNice(dx) {
   dx = Math.pow(10, Math.round(Math.log(dx) / Math.LN10) - 1);
   return {
     floor: function(x) { return Math.floor(x / dx) * dx; },
-    ceil: function(x) { return Math.ceil(x / dx) * dx; },
+    ceil: function(x) { return Math.ceil(x / dx) * dx; }
   };
 }
 

--- a/src/scale/linear.js
+++ b/src/scale/linear.js
@@ -79,7 +79,7 @@ function d3_scale_linearNice(dx) {
   dx = Math.pow(10, Math.round(Math.log(dx) / Math.LN10) - 1);
   return {
     floor: function(x) { return Math.floor(x / dx) * dx; },
-    ceil: function(x) { return Math.ceil(x / dx) * dx; },
+    ceil: function(x) { return Math.ceil(x / dx) * dx; }
   };
 }
 


### PR DESCRIPTION
Parse error. Internet Explorer has a non-standard intepretation of trailing commas. Objects will not parse at all.
