### PR TITLE
zoom bug: function and var with same name

### DIFF
--- a/d3.behavior.js
+++ b/d3.behavior.js
@@ -8,7 +8,7 @@ d3.behavior.zoom = function() {
       z = 0,
       listeners = [],
       pan,
-      zoom;
+      _zoom;
 
   function zoom() {
     var container = this
@@ -35,7 +35,7 @@ d3.behavior.zoom = function() {
   }
 
   function mousemove() {
-    zoom = null;
+    _zoom = null;
     if (pan) {
       x = d3.event.clientX + pan.x0;
       y = d3.event.clientY + pan.y0;
@@ -68,9 +68,9 @@ d3.behavior.zoom = function() {
     var e = d3.event;
 
     // initialize the mouse location for zooming (to avoid drift)
-    if (!zoom) {
+    if (!_zoom) {
       var p = d3.svg.mouse(this.nearestViewportElement || this);
-      zoom = {
+      _zoom = {
         x0: x,
         y0: y,
         z0: z,
@@ -98,9 +98,9 @@ d3.behavior.zoom = function() {
     }
 
     // adjust x and y to center around mouse location
-    var k = Math.pow(2, z - zoom.z0) - 1;
-    x = zoom.x0 + zoom.x1 * k;
-    y = zoom.y0 + zoom.y1 * k;
+    var k = Math.pow(2, z - _zoom.z0) - 1;
+    x = _zoom.x0 + _zoom.x1 * k;
+    y = _zoom.y0 + _zoom.y1 * k;
 
     // dispatch redraw
     dispatch.call(this, d, i);


### PR DESCRIPTION
Changed variable name from `zoom` to `_zoom` because there was a function called `zoom` in the same context.

As discussed in the google group: http://groups.google.com/group/d3-js/browse_thread/thread/87eaa397e7ed9e5b
