### PR TITLE
Adding two examples in dot/

### DIFF
--- a/examples/dot/dot-multiple-samples-circle.html
+++ b/examples/dot/dot-multiple-samples-circle.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Dot Plot</title>
-    <script type="text/javascript" src="../d3.js"></script>
+    <title>Dot Plot - multiple samples</title>
+    <script type="text/javascript" src="../../d3.js"></script>
     <style type="text/css">
 
 body {

--- a/examples/dot/dot-multiple-samples.html
+++ b/examples/dot/dot-multiple-samples.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Dot Plot</title>
-    <script type="text/javascript" src="../d3.js"></script>
+    <title>Dot Plot (using element circle) - multiple samples</title>
+    <script type="text/javascript" src="../../d3.js"></script>
     <style type="text/css">
 
 body {


### PR DESCRIPTION
Hi Mike, 

I thought you may be interested in this couple of examples I have added to examples/dot/
- Multiple "samples".
- Use element circle instead of dot.

Let me know,
-drd
