### PR TITLE
eliminate "this.parentNode is null" errors

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -1932,7 +1932,7 @@ function d3_transition(groups) {
           var owner = tx.owner;
           if (owner === transitionId) {
             delete this.__transition__;
-            if (remove) this.parentNode.removeChild(this);
+            if (remove && this.parentNode) this.parentNode.removeChild(this);
           }
           d3_transitionInheritId = transitionId;
           event.end.dispatch.apply(this, arguments);


### PR DESCRIPTION
verify that the node to remove after a transition actually has a parent node
