### PR TITLE
zindex selection method that handles SVG

### DIFF
--- a/src/core/selection.js
+++ b/src/core/selection.js
@@ -414,6 +414,19 @@ function d3_selection(groups) {
         ? propertyFunction : propertyConstant));
   };
 
+  groups.zindex = function(value) {
+    if(this.length != 0 && this[0].length != 0 && this[0][0].namespaceURI === "http://www.w3.org/2000/svg"){
+      // Then we need to manually reorder the elements on the DOM
+      var zcompare = function(a, b){
+        return value(a) - value(b);
+      };
+      return groups.sort(zcompare);
+    }else{
+      // We can just style the z-index
+      return groups.style("z-index", value);
+    }
+  };
+
   groups.text = function(value) {
 
     // If no value is specified, return the first value.


### PR DESCRIPTION
The quirk of SVG not supporting `z-index` has come up a few times in the group:

```
http://groups.google.com/group/d3-js/browse_thread/thread/9480326bbd980459
http://groups.google.com/group/d3-js/browse_thread/thread/a3f47cbeb1043892
```

And the correct answer seems to be, "use sort to reorder the SVG nodes".
This is a selection method that just does that for SVG, and otherwise calls style().

If you think this is okay, we should probably put a little check in the style() to call this function so people can use either

```
.style("z-index", ...)
```

or

```
.zindex(...)
```

Also please let me know if there are any style guides / pull request etiquette for D3---I looked around but couldn't find anything.
