### PR TITLE
Fix example index layout for Opera.

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,6 +61,7 @@ a:hover {
 
 .list {
   clear: left;
+  margin-top: 14px;
 }
 
 .list img {


### PR DESCRIPTION
It currently looks like this for me in Opera 11.50 on OS X:

![](http://www.jasondavies.com/tmp/Screen%20Shot%202011-08-19%20at%2011.39.45.png)
