### PR TITLE
Remove invalid octal constants.

### DIFF
--- a/test/scale/linear-test.js
+++ b/test/scale/linear-test.js
@@ -22,12 +22,12 @@ suite.addBatch({
         var x = linear().domain([new Date(1990, 0, 1), new Date(1991, 0, 1)]);
         assert.equal(typeof x.domain()[0], "number");
         assert.equal(typeof x.domain()[1], "number");
-        assert.inDelta(x(new Date(1989, 09, 20)), -.2, 1e-2);
-        assert.inDelta(x(new Date(1990, 00, 01)), 0, 1e-2);
-        assert.inDelta(x(new Date(1990, 02, 15)), .2, 1e-2);
-        assert.inDelta(x(new Date(1990, 04, 27)), .4, 1e-2);
-        assert.inDelta(x(new Date(1991, 00, 01)), 1, 1e-2);
-        assert.inDelta(x(new Date(1991, 02, 15)), 1.2, 1e-2);
+        assert.inDelta(x(new Date(1989, 9, 20)), -.2, 1e-2);
+        assert.inDelta(x(new Date(1990, 0,  1)), 0, 1e-2);
+        assert.inDelta(x(new Date(1990, 2, 15)), .2, 1e-2);
+        assert.inDelta(x(new Date(1990, 4, 27)), .4, 1e-2);
+        assert.inDelta(x(new Date(1991, 0,  1)), 1, 1e-2);
+        assert.inDelta(x(new Date(1991, 2, 15)), 1.2, 1e-2);
         var x = linear().domain(["0", "1"]);
         assert.equal(typeof x.domain()[0], "number");
         assert.equal(typeof x.domain()[1], "number");

--- a/test/scale/log-test.js
+++ b/test/scale/log-test.js
@@ -22,12 +22,12 @@ suite.addBatch({
         var x = log().domain([new Date(1990, 0, 1), new Date(1991, 0, 1)]);
         assert.equal(typeof x.domain()[0], "number");
         assert.equal(typeof x.domain()[1], "number");
-        assert.inDelta(x(new Date(1989, 09, 20)), -.2, 1e-2);
-        assert.inDelta(x(new Date(1990, 00, 01)), 0, 1e-2);
-        assert.inDelta(x(new Date(1990, 02, 15)), .2, 1e-2);
-        assert.inDelta(x(new Date(1990, 04, 27)), .4, 1e-2);
-        assert.inDelta(x(new Date(1991, 00, 01)), 1, 1e-2);
-        assert.inDelta(x(new Date(1991, 02, 15)), 1.2, 1e-2);
+        assert.inDelta(x(new Date(1989, 9, 20)), -.2, 1e-2);
+        assert.inDelta(x(new Date(1990, 0,  1)), 0, 1e-2);
+        assert.inDelta(x(new Date(1990, 2, 15)), .2, 1e-2);
+        assert.inDelta(x(new Date(1990, 4, 27)), .4, 1e-2);
+        assert.inDelta(x(new Date(1991, 0,  1)), 1, 1e-2);
+        assert.inDelta(x(new Date(1991, 2, 15)), 1.2, 1e-2);
         var x = log().domain(["1", "10"]);
         assert.equal(typeof x.domain()[0], "number");
         assert.equal(typeof x.domain()[1], "number");

--- a/test/scale/pow-test.js
+++ b/test/scale/pow-test.js
@@ -22,12 +22,12 @@ suite.addBatch({
         var x = pow().domain([new Date(1990, 0, 1), new Date(1991, 0, 1)]);
         assert.equal(typeof x.domain()[0], "number");
         assert.equal(typeof x.domain()[1], "number");
-        assert.inDelta(x(new Date(1989, 09, 20)), -.2, 1e-2);
-        assert.inDelta(x(new Date(1990, 00, 01)), 0, 1e-2);
-        assert.inDelta(x(new Date(1990, 02, 15)), .2, 1e-2);
-        assert.inDelta(x(new Date(1990, 04, 27)), .4, 1e-2);
-        assert.inDelta(x(new Date(1991, 00, 01)), 1, 1e-2);
-        assert.inDelta(x(new Date(1991, 02, 15)), 1.2, 1e-2);
+        assert.inDelta(x(new Date(1989, 9, 20)), -.2, 1e-2);
+        assert.inDelta(x(new Date(1990, 0,  1)), 0, 1e-2);
+        assert.inDelta(x(new Date(1990, 2, 15)), .2, 1e-2);
+        assert.inDelta(x(new Date(1990, 4, 27)), .4, 1e-2);
+        assert.inDelta(x(new Date(1991, 0,  1)), 1, 1e-2);
+        assert.inDelta(x(new Date(1991, 2, 15)), 1.2, 1e-2);
         var x = pow().domain(["0", "1"]);
         assert.equal(typeof x.domain()[0], "number");
         assert.equal(typeof x.domain()[1], "number");

--- a/test/scale/sqrt-test.js
+++ b/test/scale/sqrt-test.js
@@ -22,12 +22,12 @@ suite.addBatch({
         var x = sqrt().domain([new Date(1990, 0, 1), new Date(1991, 0, 1)]);
         assert.equal(typeof x.domain()[0], "number");
         assert.equal(typeof x.domain()[1], "number");
-        assert.inDelta(x(new Date(1989, 09, 20)), -.2, 1e-2);
-        assert.inDelta(x(new Date(1990, 00, 01)), 0, 1e-2);
-        assert.inDelta(x(new Date(1990, 02, 15)), .2, 1e-2);
-        assert.inDelta(x(new Date(1990, 04, 27)), .4, 1e-2);
-        assert.inDelta(x(new Date(1991, 00, 01)), 1, 1e-2);
-        assert.inDelta(x(new Date(1991, 02, 15)), 1.2, 1e-2);
+        assert.inDelta(x(new Date(1989, 9, 20)), -.2, 1e-2);
+        assert.inDelta(x(new Date(1990, 0,  1)), 0, 1e-2);
+        assert.inDelta(x(new Date(1990, 2, 15)), .2, 1e-2);
+        assert.inDelta(x(new Date(1990, 4, 27)), .4, 1e-2);
+        assert.inDelta(x(new Date(1991, 0,  1)), 1, 1e-2);
+        assert.inDelta(x(new Date(1991, 2, 15)), 1.2, 1e-2);
         var x = sqrt().domain(["0", "1"]);
         assert.equal(typeof x.domain()[0], "number");
         assert.equal(typeof x.domain()[1], "number");

--- a/test/time/scale-test.js
+++ b/test/time/scale-test.js
@@ -272,13 +272,13 @@ suite.addBatch({
       },
       "formats minute on second zero": function(format) {
         assert.equal(format(local(2011, 1, 2, 11, 59)), "11:59");
-        assert.equal(format(local(2011, 1, 2, 12, 01)), "12:01");
-        assert.equal(format(local(2011, 1, 2, 12, 02)), "12:02");
+        assert.equal(format(local(2011, 1, 2, 12,  1)), "12:01");
+        assert.equal(format(local(2011, 1, 2, 12,  2)), "12:02");
       },
       "otherwise, formats second": function(format) {
-        assert.equal(format(local(2011, 1, 2, 12, 01, 09)), ":09");
-        assert.equal(format(local(2011, 1, 2, 12, 01, 10)), ":10");
-        assert.equal(format(local(2011, 1, 2, 12, 01, 11)), ":11");
+        assert.equal(format(local(2011, 1, 2, 12, 1,  9)), ":09");
+        assert.equal(format(local(2011, 1, 2, 12, 1, 10)), ":10");
+        assert.equal(format(local(2011, 1, 2, 12, 1, 11)), ":11");
       }
     },
 
@@ -501,13 +501,13 @@ suite.addBatch({
         },
         "formats minute on second zero": function(format) {
           assert.equal(format(utc(2011, 1, 2, 11, 59)), "11:59");
-          assert.equal(format(utc(2011, 1, 2, 12, 01)), "12:01");
-          assert.equal(format(utc(2011, 1, 2, 12, 02)), "12:02");
+          assert.equal(format(utc(2011, 1, 2, 12,  1)), "12:01");
+          assert.equal(format(utc(2011, 1, 2, 12,  2)), "12:02");
         },
         "otherwise, formats second": function(format) {
-          assert.equal(format(utc(2011, 1, 2, 12, 01, 09)), ":09");
-          assert.equal(format(utc(2011, 1, 2, 12, 01, 10)), ":10");
-          assert.equal(format(utc(2011, 1, 2, 12, 01, 11)), ":11");
+          assert.equal(format(utc(2011, 1, 2, 12, 1,  9)), ":09");
+          assert.equal(format(utc(2011, 1, 2, 12, 1, 10)), ":10");
+          assert.equal(format(utc(2011, 1, 2, 12, 1, 11)), ":11");
         }
       }
     }


### PR DESCRIPTION
08 and 09 are not legal octal constants according to ECMA-262, although they seem to work fine in V8.  I removed other octal constants too for good measure, but retained alignment where appropriate.
