### PR TITLE
Fix width/height of treemap-svg example.

### DIFF
--- a/examples/treemap/treemap-svg.js
+++ b/examples/treemap/treemap-svg.js
@@ -8,8 +8,8 @@ var treemap = d3.layout.treemap()
     .value(function(d) { return d.size; });
 
 var svg = d3.select("body").append("svg:svg")
-    .style("width", w)
-    .style("height", h)
+    .attr("width", w)
+    .attr("height", h)
   .append("svg:g")
     .attr("transform", "translate(-.5,-.5)");
 


### PR DESCRIPTION
In IE9, using style("width", 960) fails with "SCRIPT87: invalid argument" because strictly speaking, non-zero CSS widths need a unit e.g. "960px".  In SVG, we normally use width/height attributes via attr() instead of the CSS equivalents.
