### PR TITLE
fix sigfig ('r') formatting with precision using zero as input

### DIFF
--- a/src/core/format.js
+++ b/src/core/format.js
@@ -66,6 +66,7 @@ var d3_format_types = {
   e: function(x, p) { return x.toExponential(p); },
   f: function(x, p) { return x.toFixed(p); },
   r: function(x, p) {
+    if (x == 0) return x.toPrecision(p);
     var n = 1 + Math.floor(1e-15 + Math.log(x) / Math.LN10);
     return d3.round(x, p - n).toFixed(Math.max(0, Math.min(20, p - n)));
   }

--- a/test/core/format-test.js
+++ b/test/core/format-test.js
@@ -92,6 +92,7 @@ suite.addBatch({
       assert.strictEqual(f(-1.23), "−120%");
     },
     "can round to significant digits": function(format) {
+      assert.strictEqual(format(".2r")(0), "0.0");
       assert.strictEqual(format(".1r")(0.049), "0.05");
       assert.strictEqual(format(".1r")(0.49), "0.5");
       assert.strictEqual(format(".2r")(0.449), "0.45");


### PR DESCRIPTION
presently this returns NaN due to an attempt at taking the log of zero. i've special-cased it out to just short-circuit to .toPrecision(p) on zero input.
