### PR TITLE
Npm doesn't necessarily install dependencies under d3/node_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # See the README for installation instructions.
 
-JS_COMPILER = ./node_modules/uglify-js/bin/uglifyjs
-JS_TESTER = ./node_modules/vows/bin/vows
+NODE_PATH ?= ./node_modules
+JS_COMPILER = $(NODE_PATH)/uglify-js/bin/uglifyjs
+JS_TESTER = $(NODE_PATH)/vows/bin/vows
 
 all: \
 	d3.js \

--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ Next, from the root directory of this repository, install D3's dependencies:
 
     npm install
 
-You can see the list of dependencies in package.json. The packages will be
-installed in the node_modules directory.
+You can see the list of dependencies in package.json. Npm will install the
+packages in your $NODE_PATH, or in the node_modules directory, if unset.


### PR DESCRIPTION
On my system (homebrew 0.8, node.js 0.4.8, npm 0.3.18), "npm install" installs d3's dependencies below /usr/local/lib/node (<code>$NODE_PATH</code>), not <code>d3/node_modules</code> – this tweak should make "make test" work with either configuration.
