### PR TITLE
Minor cleanup of force-cluster example.

### DIFF
--- a/examples/force/force-cluster.html
+++ b/examples/force/force-cluster.html
@@ -197,12 +197,12 @@ function init() {
 
   hullg.selectAll("path.hull").remove();
   hull = hullg.selectAll("path.hull")
-     .data(convexHulls(net.nodes, getGroup, off))
+      .data(convexHulls(net.nodes, getGroup, off))
     .enter().append("svg:path")
-     .attr("class", "hull")
-     .attr("d", drawCluster)
-     .style("fill", function(d) { return fill(d.group); })
-     .on("dblclick", function(d) { expand[d.group] = false; init(); });
+      .attr("class", "hull")
+      .attr("d", drawCluster)
+      .style("fill", function(d) { return fill(d.group); })
+      .on("dblclick", function(d) { expand[d.group] = false; init(); });
 
   link = linkg.selectAll("line.link").data(net.links, linkid);
   link.exit().remove();
@@ -213,7 +213,6 @@ function init() {
       .attr("x2", function(d) { return d.target.x; })
       .attr("y2", function(d) { return d.target.y; })
       .style("stroke-width", function(d) { return d.size || 1; });
-  link = linkg.selectAll("line.link");
 
   node = nodeg.selectAll("circle.node").data(net.nodes, nodeid);
   node.exit().remove();
@@ -227,8 +226,7 @@ function init() {
         if (d.size) { expand[d.group] = true; init(); }
       });
 
-  node = nodeg.selectAll("circle.node")
-      .call(force.drag);
+  node.call(force.drag);
 
   force.on("tick", function() {
     if (!hull.empty()) {


### PR DESCRIPTION
We don't need to reselect now that appending nodes to the entering selection are automatically added to the updating selection.
