### PR TITLE
fix bug that causes chord layout to break in Opera

### DIFF
--- a/src/layout/chord.js
+++ b/src/layout/chord.js
@@ -64,9 +64,10 @@ d3.layout.chord = function() {
           index: di,
           subindex: dj,
           startAngle: x,
-          endAngle: x += v * k,
+          endAngle: x + v * k,
           value: v
         };
+        x += v * k;
       }
       groups.push({
         index: di,


### PR DESCRIPTION
The chord layout uses an assigment like x += y to specify the end angle of a
chord segment. This seems to return the new value in most browsers, but the old
value (i.e. x - y) in Opera.
