### PR TITLE
make Makefile GNU make v3.82 compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,19 @@ NODE_PATH ?= ./node_modules
 JS_COMPILER = $(NODE_PATH)/uglify-js/bin/uglifyjs
 JS_TESTER = $(NODE_PATH)/vows/bin/vows
 
+JS_FILES = \
+    d3.js \
+    d3.chart.js \
+    d3.layout.js \
+    d3.csv.js \
+    d3.geo.js \
+    d3.geom.js \
+    d3.time.js
+
 all: \
-	d3.js \
-	d3.min.js \
-	d3.chart.js \
-	d3.chart.min.js \
-	d3.layout.js \
-	d3.layout.min.js \
-	d3.csv.js \
-	d3.csv.min.js \
-	d3.geo.js \
-	d3.geo.min.js \
-	d3.geom.js \
-	d3.geom.min.js \
-	d3.time.js \
-	d3.time.min.js \
-	package.json
+  $(JS_FILES) \
+  $(JS_FILES:.js=.min.js) \
+  package.json
 
 # Modify this rule to build your own custom release.
 # Run `make d3.custom.min.js` to produce the minified version.
@@ -245,12 +242,7 @@ test: all
 	@rm -f $@
 	$(JS_COMPILER) < $< > $@
 
-d3.js: Makefile
-	@rm -f $@
-	cat $(filter %.js,$^) > $@
-	@chmod a-w $@
-
-d3%.js: Makefile
+d3.%: Makefile
 	@rm -f $@
 	cat $(filter %.js,$^) > $@
 	@chmod a-w $@


### PR DESCRIPTION
Quote from NEWS file:

In previous versions of make it was acceptable to list one or more explicit
targets followed by one or more pattern targets in the same rule and it
worked "as expected". However, this was not documented as acceptable and if
you listed any explicit targets AFTER the pattern targets, the entire rule
would be mis-parsed. This release removes this ability completely: make
will generate an error message if you mix explicit and pattern targets in
the same rule.
