### PR TITLE
add geotranslate method to projections and tests

### DIFF
--- a/src/geo/albers.js
+++ b/src/geo/albers.js
@@ -7,6 +7,7 @@ d3.geo.albers = function() {
       parallels = [29.5, 45.5],
       scale = 1000,
       translate = [480, 250],
+      geotranslate = geotranslate_ = [0, 0],
       lng0, // d3_geo_radians * origin[0]
       n,
       C,
@@ -16,14 +17,14 @@ d3.geo.albers = function() {
     var t = n * (d3_geo_radians * coordinates[0] - lng0),
         p = Math.sqrt(C - 2 * n * Math.sin(d3_geo_radians * coordinates[1])) / n;
     return [
-      scale * p * Math.sin(t) + translate[0],
-      scale * (p * Math.cos(t) - p0) + translate[1]
+      scale * p * Math.sin(t) + translate[0] - geotranslate_[0],
+      scale * (p * Math.cos(t) - p0) + translate[1] - geotranslate_[1]
     ];
   }
 
   albers.invert = function(coordinates) {
-    var x = (coordinates[0] - translate[0]) / scale,
-        y = (coordinates[1] - translate[1]) / scale,
+    var x = (coordinates[0] - translate[0] + geotranslate_[0]) / scale,
+        y = (coordinates[1] - translate[1] + geotranslate_[1]) / scale,
         p0y = p0 + y,
         t = Math.atan2(x, p0y),
         p = Math.sqrt(x * x + p0y * p0y);
@@ -61,12 +62,26 @@ d3.geo.albers = function() {
   albers.scale = function(x) {
     if (!arguments.length) return scale;
     scale = +x;
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return albers;
   };
 
   albers.translate = function(x) {
     if (!arguments.length) return translate;
     translate = [+x[0], +x[1]];
+    return albers;
+  };
+
+  albers.geotranslate = function(x) {
+    if (!arguments.length) return geotranslate;
+    geotranslate = [+x[0], +x[1]];
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return albers;
   };
 

--- a/src/geo/azimuthal.js
+++ b/src/geo/azimuthal.js
@@ -4,6 +4,7 @@ d3.geo.azimuthal = function() {
       origin,
       scale = 200,
       translate = [480, 250],
+      geotranslate = geotranslate_ = [0, 0],
       x0,
       y0,
       cy0,
@@ -26,14 +27,14 @@ d3.geo.azimuthal = function() {
         x = k * cy1 * sx1,
         y = k * (sy0 * cy1 * cx1 - cy0 * sy1);
     return [
-      scale * x + translate[0],
-      scale * y + translate[1]
+      scale * x + translate[0] - geotranslate_[0],
+      scale * y + translate[1] - geotranslate_[1]
     ];
   }
 
   azimuthal.invert = function(coordinates) {
-    var x = (coordinates[0] - translate[0]) / scale,
-        y = (coordinates[1] - translate[1]) / scale,
+    var x = (coordinates[0] - translate[0] + geotranslate_[0]) / scale,
+        y = (coordinates[1] - translate[1] + geotranslate_[1]) / scale,
         p = Math.sqrt(x * x + y * y),
         c = mode === "stereographic" ? 2 * Math.atan(p)
           : mode === "gnomonic" ? Math.atan(p)
@@ -67,12 +68,26 @@ d3.geo.azimuthal = function() {
   azimuthal.scale = function(x) {
     if (!arguments.length) return scale;
     scale = +x;
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return azimuthal;
   };
 
   azimuthal.translate = function(x) {
     if (!arguments.length) return translate;
     translate = [+x[0], +x[1]];
+    return azimuthal;
+  };
+
+  azimuthal.geotranslate = function(x) {
+    if (!arguments.length) return geotranslate;
+    geotranslate = [+x[0], +x[1]];
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return azimuthal;
   };
 

--- a/src/geo/bonne.js
+++ b/src/geo/bonne.js
@@ -1,6 +1,7 @@
 d3.geo.bonne = function() {
   var scale = 200,
       translate = [480, 250],
+      geotranslate = geotranslate_ = [0, 0],
       x0, // origin longitude in radians
       y0, // origin latitude in radians
       y1, // parallel latitude in radians
@@ -18,14 +19,14 @@ d3.geo.bonne = function() {
       y *= -1;
     }
     return [
-      scale * x + translate[0],
-      scale * y + translate[1]
+      scale * x + translate[0] - geotranslate_[0],
+      scale * y + translate[1] - geotranslate_[1]
     ];
   }
 
   bonne.invert = function(coordinates) {
-    var x = (coordinates[0] - translate[0]) / scale,
-        y = (coordinates[1] - translate[1]) / scale;
+    var x = (coordinates[0] - translate[0] + geotranslate_[0]) / scale,
+        y = (coordinates[1] - translate[1] + geotranslate_[1]) / scale;
     if (y1) {
       var c = c1 + y, p = Math.sqrt(x * x + c * c);
       y = c1 + y1 - p;
@@ -57,12 +58,26 @@ d3.geo.bonne = function() {
   bonne.scale = function(x) {
     if (!arguments.length) return scale;
     scale = +x;
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return bonne;
   };
 
   bonne.translate = function(x) {
     if (!arguments.length) return translate;
     translate = [+x[0], +x[1]];
+    return bonne;
+  };
+
+  bonne.geotranslate = function(x) {
+    if (!arguments.length) return geotranslate;
+    geotranslate = [+x[0], +x[1]];
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return bonne;
   };
 

--- a/src/geo/equirectangular.js
+++ b/src/geo/equirectangular.js
@@ -1,19 +1,20 @@
 d3.geo.equirectangular = function() {
   var scale = 500,
-      translate = [480, 250];
+      translate = [480, 250],
+      geotranslate = geotranslate_ = [0, 0];
 
   function equirectangular(coordinates) {
     var x = coordinates[0] / 360,
         y = -coordinates[1] / 360;
     return [
-      scale * x + translate[0],
-      scale * y + translate[1]
+      scale * x + translate[0] - geotranslate_[0],
+      scale * y + translate[1] - geotranslate_[1]
     ];
   }
 
   equirectangular.invert = function(coordinates) {
-    var x = (coordinates[0] - translate[0]) / scale,
-        y = (coordinates[1] - translate[1]) / scale;
+    var x = (coordinates[0] - translate[0] + geotranslate_[0]) / scale,
+        y = (coordinates[1] - translate[1] + geotranslate_[1]) / scale;
     return [
       360 * x,
       -360 * y
@@ -23,12 +24,26 @@ d3.geo.equirectangular = function() {
   equirectangular.scale = function(x) {
     if (!arguments.length) return scale;
     scale = +x;
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return equirectangular;
   };
 
   equirectangular.translate = function(x) {
     if (!arguments.length) return translate;
     translate = [+x[0], +x[1]];
+    return equirectangular;
+  };
+
+  equirectangular.geotranslate = function(x) {
+    if (!arguments.length) return geotranslate;
+    geotranslate = [+x[0], +x[1]];
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return equirectangular;
   };
 

--- a/src/geo/mercator.js
+++ b/src/geo/mercator.js
@@ -1,19 +1,20 @@
 d3.geo.mercator = function() {
   var scale = 500,
-      translate = [480, 250];
+      translate = [480, 250],
+      geotranslate = geotranslate_ = [0, 0];
 
   function mercator(coordinates) {
     var x = coordinates[0] / 360,
         y = -(Math.log(Math.tan(Math.PI / 4 + coordinates[1] * d3_geo_radians / 2)) / d3_geo_radians) / 360;
     return [
-      scale * x + translate[0],
-      scale * Math.max(-.5, Math.min(.5, y)) + translate[1]
+      scale * x + translate[0] - geotranslate_[0],
+      scale * Math.max(-.5, Math.min(.5, y)) + translate[1] - geotranslate_[1]
     ];
   }
 
   mercator.invert = function(coordinates) {
-    var x = (coordinates[0] - translate[0]) / scale,
-        y = (coordinates[1] - translate[1]) / scale;
+    var x = (coordinates[0] - translate[0] + geotranslate_[0]) / scale,
+        y = (coordinates[1] - translate[1] + geotranslate_[1]) / scale;
     return [
       360 * x,
       2 * Math.atan(Math.exp(-360 * y * d3_geo_radians)) / d3_geo_radians - 90
@@ -23,12 +24,26 @@ d3.geo.mercator = function() {
   mercator.scale = function(x) {
     if (!arguments.length) return scale;
     scale = +x;
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return mercator;
   };
 
   mercator.translate = function(x) {
     if (!arguments.length) return translate;
     translate = [+x[0], +x[1]];
+    return mercator;
+  };
+
+  mercator.geotranslate = function(x) {
+    if (!arguments.length) return geotranslate;
+    geotranslate = [+x[0], +x[1]];
+    geotranslate_ = [0, 0];
+    if(geotranslate[0] != 0 && geotranslate[1] != 0) {
+        geotranslate_ = this(geotranslate);
+    }
     return mercator;
   };
 

--- a/test/geo/albers-test.js
+++ b/test/geo/albers-test.js
@@ -50,6 +50,26 @@ suite.addBatch({
           lonlat = albers.invert(coords);
       assert.inDelta(lonlat[0], 0, 1e-6);
       assert.inDelta(lonlat[1], 85, 1e-6);
+    },
+    "geotranslate": {
+      "defaults to [0, 0]": function(projection) {
+        assert.deepEqual(projection.geotranslate(), [0, 0]);
+      },
+      "translates coordinates": function(projection) {
+        var sf = [-122.446, 37.767];
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.geotranslate([0,0]);
+      },
+      "is scale-independent": function(projection) {
+        var sf = [-122.446, 37.767], scale = projection.scale();
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(2*scale);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(scale);
+        projection.geotranslate([0,0]);
+      }
     }
   }
 });

--- a/test/geo/azimuthal-test.js
+++ b/test/geo/azimuthal-test.js
@@ -254,6 +254,26 @@ suite.addBatch({
           lonlat = azimuthal.invert(coords);
       assert.inDelta(lonlat[0], 0, 1e-6);
       assert.inDelta(lonlat[1], 85, 1e-6);
+    },
+    "geotranslate": {
+      "defaults to [0, 0]": function(projection) {
+        assert.deepEqual(projection.geotranslate(), [0, 0]);
+      },
+      "translates coordinates": function(projection) {
+        var sf = [-122.446, 37.767];
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.geotranslate([0,0]);
+      },
+      "is scale-independent": function(projection) {
+        var sf = [-122.446, 37.767], scale = projection.scale();
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(2*scale);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(scale);
+        projection.geotranslate([0,0]);
+      }
     }
   }
 });

--- a/test/geo/bonne-test.js
+++ b/test/geo/bonne-test.js
@@ -23,6 +23,26 @@ suite.addBatch({
     },
     "translate defaults to [480, 250]": function(bonne) {
       assert.deepEqual(bonne.translate(), [480, 250]);
+    },
+    "geotranslate": {
+      "defaults to [0, 0]": function(projection) {
+        assert.deepEqual(projection.geotranslate(), [0, 0]);
+      },
+      "translates coordinates": function(projection) {
+        var sf = [-122.446, 37.767];
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.geotranslate([0,0]);
+      },
+      "is scale-independent": function(projection) {
+        var sf = [-122.446, 37.767], scale = projection.scale();
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(2*scale);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(scale);
+        projection.geotranslate([0,0]);
+      }
     }
   },
 

--- a/test/geo/equirectangular-test.js
+++ b/test/geo/equirectangular-test.js
@@ -36,6 +36,27 @@ suite.addBatch({
       }
     },
 
+    "geotranslate": {
+      "defaults to [0, 0]": function(projection) {
+        assert.deepEqual(projection.geotranslate(), [0, 0]);
+      },
+      "translates coordinates": function(projection) {
+        var sf = [-122.446, 37.767];
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.geotranslate([0,0]);
+      },
+      "is scale-independent": function(projection) {
+        var sf = [-122.446, 37.767], scale = projection.scale();
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(2*scale);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(scale);
+        projection.geotranslate([0,0]);
+      }
+    },
+
     "of San Francisco, CA": {
       "is at location [-122.446, 37.767]": function(projection) {
         assert.inDelta(projection.invert([310, 198]), [-122.446, 37.767], .5);

--- a/test/geo/mercator-test.js
+++ b/test/geo/mercator-test.js
@@ -50,6 +50,26 @@ suite.addBatch({
           lonlat = mercator.invert(coords);
       assert.inDelta(lonlat[0], 0, 1e-6);
       assert.inDelta(lonlat[1], 85, 1e-6);
+    },
+    "geotranslate": {
+      "defaults to [0, 0]": function(projection) {
+        assert.deepEqual(projection.geotranslate(), [0, 0]);
+      },
+      "translates coordinates": function(projection) {
+        var sf = [-122.446, 37.767];
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.geotranslate([0,0]);
+      },
+      "is scale-independent": function(projection) {
+        var sf = [-122.446, 37.767], scale = projection.scale();
+        projection.geotranslate(sf);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(2*scale);
+        assert.inDelta(projection(sf), [0, 0], .5);
+        projection.scale(scale);
+        projection.geotranslate([0,0]);
+      }
     }
   }
 });


### PR DESCRIPTION
Geotranslate works like translate but takes projection coordinates as input. It
is also scale independent, i.e. there is no need to adjust geotranslate after
changing the scale. The primary use of this function is to move the map to a
specific place.

Unfortunately this introduces some repeated code to maintain the translation internally independent of the scale. I didn't find a good way of avoiding this though and would be grateful for any pointers.
