### PR TITLE
Update JSDOM and Vows versions (Node.js v0.6.x compatibility).

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "d3.js",
   "dependencies": {
     "uglify-js": "1.1.1",
-    "jsdom": "0.2.8",
-    "vows": "0.5.11"
+    "jsdom": "0.2.9",
+    "vows": "0.5.13"
   }
 }

--- a/src/package.js
+++ b/src/package.js
@@ -12,7 +12,7 @@ require("util").puts(JSON.stringify({
   "main": "d3.js",
   "dependencies": {
     "uglify-js": "1.1.1",
-    "jsdom": "0.2.8",
-    "vows": "0.5.11"
+    "jsdom": "0.2.9",
+    "vows": "0.5.13"
   }
 }, null, 2));

--- a/test/core/select-test.js
+++ b/test/core/select-test.js
@@ -33,8 +33,8 @@ suite.addBatch({
     "selects by node": function() {
       var div = d3.select(document.body.lastChild);
       assert.isTrue(div[0][0] === document.body.lastChild);
-      assert.length(div, 1);
-      assert.length(div[0], 1);
+      assert.lengthOf(div, 1);
+      assert.lengthOf(div[0], 1);
     }
   }
 });

--- a/test/core/selectAll-test.js
+++ b/test/core/selectAll-test.js
@@ -33,8 +33,8 @@ suite.addBatch({
     "selects by array": function() {
       var div = d3.selectAll([document.body.lastChild]);
       assert.isTrue(div[0][0] === document.body.lastChild);
-      assert.length(div, 1);
-      assert.length(div[0], 1);
+      assert.lengthOf(div, 1);
+      assert.lengthOf(div[0], 1);
     },
     "groups are not instances of NodeList": function() {
       var div = d3.select("body").selectAll(function() { return this.getElementsByClassName("div"); });

--- a/test/scale/category-test.js
+++ b/test/scale/category-test.js
@@ -17,8 +17,8 @@ function category(category, n) {
   return {
     "is an ordinal scale": function() {
       var x = category(), colors = x.range();
-      assert.length(x.domain(), 0);
-      assert.length(x.range(), n);
+      assert.lengthOf(x.domain(), 0);
+      assert.lengthOf(x.range(), n);
       assert.equal(x(1), colors[0]);
       assert.equal(x(2), colors[1]);
       assert.equal(x(1), colors[0]);
@@ -39,7 +39,7 @@ function category(category, n) {
     },
     "contains the expected number of values in the range": function() {
       var x = category();
-      assert.length(x.range(), n);
+      assert.lengthOf(x.range(), n);
     },
     "each range value is distinct": function() {
       var map = {}, count = 0, x = category();


### PR DESCRIPTION
This required changing assert.length to assert.lengthOf in tests, due to a Vows.js change to be compatible with Node.js v0.6.x.  [Further details](https://github.com/cloudhead/vows/pull/141).

Hence this also makes the D3.js test suite fully compatible with Node.js v0.6.x.
