### PR TITLE
Update dependencies and use "devDependencies".

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "url": "http://github.com/mbostock/d3.git"
   },
   "main": "d3.js",
+  "dependencies": {
+    "jsdom": "0.2.10"
+  },
   "devDependencies": {
     "uglify-js": "1.2.3",
-    "jsdom": "0.2.10",
-    "vows": "0.6.1"
+    "vows": "0.6.x"
   },
   "scripts": {
     "test": "./node_modules/vows/bin/vows"

--- a/src/package.js
+++ b/src/package.js
@@ -10,10 +10,12 @@ require("util").puts(JSON.stringify({
   "author": {"name": "Mike Bostock", "url": "http://bost.ocks.org/mike"},
   "repository": {"type": "git", "url": "http://github.com/mbostock/d3.git"},
   "main": "d3.js",
+  "dependencies": {
+    "jsdom": "0.2.10"
+  },
   "devDependencies": {
     "uglify-js": "1.2.3",
-    "jsdom": "0.2.10",
-    "vows": "0.6.1"
+    "vows": "0.6.x"
   },
   "scripts": {"test": "./node_modules/vows/bin/vows"}
 }, null, 2));


### PR DESCRIPTION
Using "devDependencies" prevents "vows" etc. from being installed if D3 is being installed as a dependency. I'm not sure whether "jsdom" counts as a true dependency or not as we only really use it for the tests.

I've also added a "scripts": {"test": …} parameter, which specifies what happens when you run "npm test".
