### PR TITLE
bugfix for the calendar display (e.g. http://mbostock.github.com/d3/ex/calendar.html)

### DIFF
--- a/examples/calendar/dji.js
+++ b/examples/calendar/dji.js
@@ -48,7 +48,7 @@ d3.csv("dji.csv", function(csv) {
     .map(csv);
 
   rect
-      .attr("class", function(d) { 
+      .attr("class", function(d) {
 		var dv = data[format(d)];
 		return "day q" + (dv ? color(dv) : "X") + "-9"; })
     .append("title")
@@ -56,7 +56,7 @@ d3.csv("dji.csv", function(csv) {
 });
 
 function monthPath(t0) {
-  var t1 = new Date(t0.getUTCFullYear(), t0.getUTCMonth() + 2, 0),
+  var t1 = new Date(t0.getFullYear(), t0.getMonth() + 1, 0),
       d0 = +day(t0), w0 = +week(t0),
       d1 = +day(t1), w1 = +week(t1);
   return "M" + (w0 + 1) * z + "," + d0 * z

--- a/examples/calendar/vix.js
+++ b/examples/calendar/vix.js
@@ -48,7 +48,7 @@ d3.csv("vix.csv", function(csv) {
   color.domain(d3.values(data));
 
   rect
-    .attr("class", function(d) { 
+    .attr("class", function(d) {
       var dv = data[format(d)];
       return "day q" + (dv ? color(dv) : "X") + "-9"; })
     .append("title")
@@ -56,7 +56,7 @@ d3.csv("vix.csv", function(csv) {
 });
 
 function monthPath(t0) {
-  var t1 = new Date(t0.getUTCFullYear(), t0.getUTCMonth() + 2, 0),
+  var t1 = new Date(t0.getFullYear(), t0.getMonth() + 1, 0),
       d0 = +day(t0), w0 = +week(t0),
       d1 = +day(t1), w1 = +week(t1);
   return "M" + (w0 + 1) * z + "," + d0 * z


### PR DESCRIPTION
This edit fixes the days vs. months outline drawing error as visible at, f.e.:
  http://mbostock.github.com/d3/ex/calendar.html

The magic is to replace 
  .getUTCMonth() + 1
with
  .getUTCMonth() + 2
so that each calculated month' outline renders the outline for one month only - the original code rendered an outline around the whole year, then separate lines between the months within the year, where the latter are double-drawn as both halves of the calculated path overlap.

The other bit of change assigns the 'qX-9' class for day cells which do not have a data value. Merely a cosmetic/superfluous thing.
