### PR TITLE
New pluck function to easily obtain an array of values from common properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ d3.core.js: \
 	src/core/range.js \
 	src/core/requote.js \
 	src/core/round.js \
+	src/core/pluck.js \
 	src/core/xhr.js \
 	src/core/text.js \
 	src/core/json.js \

--- a/src/core/pluck.js
+++ b/src/core/pluck.js
@@ -1,0 +1,3 @@
+d3.pluck = function(items, key, byDefault) {
+  return items.map(function(item){ return (key in item) ? item[key] : byDefault; });
+};

--- a/test/core/pluck-test.js
+++ b/test/core/pluck-test.js
@@ -1,0 +1,26 @@
+require("../env");
+require("../../d3");
+
+var vows = require("vows"),
+    assert = require("assert");
+
+var suite = vows.describe("d3.pluck");
+
+suite.addBatch({
+  "pluck": {
+    topic: function() {
+      return d3.pluck;
+    },
+    "enumerates every item property": function(pluck) {
+      assert.deepEqual(pluck([{a: 1, b: 2}, {a: 3, b: 4}, {a: 5}], 'a'), [1, 3, 5]);
+    },
+    "enumerates array items by index": function(pluck){
+      assert.deepEqual(pluck([[1,2],[3,4],[5,6]], 1), [2, 4, 6]); 
+    },
+    "injects a default value if the property is undefined": function(pluck){
+      assert.deepEqual(pluck([{a: 1, b: 2}, {a: 3}, {a: 4, b: 5}], 'b', 0), [2, 0, 5]);
+    }
+  }
+});
+
+suite.export(module);


### PR DESCRIPTION
Included a new `d3.pluck` function to easily obtain an array of values from a common property in a list of objects or nested arrays. This is extremely useful when computing domains for example, since it avoids the need for custom map functions.

Additionally it also allows to define a default value as third argument to be returned in the case that the given property is not defined in some of the nested objects.

```
var data = [ {x:100, y:'Sp'}, {x:120, y:'Uk'}, {x: 60, y:'Fr'}, {y: 'Gr'} ];
xScale.domain([0, d3.max(d3.pluck(data, 'x', 0))]);
yScale.domain(d.pluck(data, 'y'));
//xScale.domain([0, d3.max(data, function(d){ return d.x; })]);
//yScale.domain(data.map(function(d){ return d.y; }));
```
