### PR TITLE
Make the voronoi implementation extensible.

### DIFF
--- a/src/geom/voronoi.js
+++ b/src/geom/voronoi.js
@@ -18,7 +18,7 @@
  * @param vertices [[x1, y1], [x2, y2], …]
  * @returns polygons [[[x1, y1], [x2, y2], …], …]
  */
-d3.geom.voronoi = function(vertices) {
+d3.geom.voronoi = function(vertices, edgeCallback) {
   var polygons = vertices.map(function() { return []; }),
       Z = 1e6;
 
@@ -49,6 +49,15 @@ d3.geom.voronoi = function(vertices) {
     }
     var v1 = [x1, y1],
         v2 = [x2, y2];
+
+    if (typeof edgeCallback === "function") {
+       edgeCallback.apply(this, [ { 
+         left: e.region.l.index, 
+         right: e.region.r.index,
+         v1: v1, v2: v2 
+       }]);
+    }
+    
     polygons[e.region.l.index].push(v1, v2);
     polygons[e.region.r.index].push(v1, v2);
   });


### PR DESCRIPTION
This is a relative small change that makes d3.geom.voronoi more extensible. The current implementation assumes that users are only interested in the cell boundaries. However, for some code I'm working on I also need the neighbors of each cell.

In order to make this possible with as little changes as possible I propose this patch. In stead of calling d3.geom.voronoi only with a set of vertices it now also takes an optional callback parameter. This parameter should be an object that provides two methods:

* handle(e) // Handle edge addition
* result()    // finalize and return results.

In my patch the default behavior of d3.geom.voronoi is unchanged as I moved the original anonymous function into a default edgehandler which is used when the handler parameter is undefined.

This patch allows me to install my own edgehandler which records the required information.

Comments, questions and suggestions for improvements welcome of course.

Cheers,

Bertjan