### PR TITLE
initial implementation of variable width line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ d3.svg.js: \
 	src/svg/arc.js \
 	src/svg/line.js \
 	src/svg/line-radial.js \
+	src/svg/line-variable.js \
 	src/svg/area.js \
 	src/svg/area-radial.js \
 	src/svg/chord.js \

--- a/src/svg/line-variable.js
+++ b/src/svg/line-variable.js
@@ -1,0 +1,106 @@
+d3.svg.line.variable = function() {
+    return d3_svg_lineVariable();
+}
+
+function d3_svg_lineVariable() {
+    var x = function(d) { return d[0]; },
+        y = function(d) { return d[1]; },
+        w = 5,
+        intpol = "linear",
+        t = .7;
+
+    function lineVariable(d) {
+        return d.length < 1 ? null :
+            d3_svg_lineVariablePoints(this, d, x, y, w, intpol, t) + "Z";
+    }
+
+    lineVariable.x = function(v) {
+        if(!arguments.length) return x;
+        x = v;
+        return lineVariable;
+    };
+
+    lineVariable.y = function(v) {
+        if(!arguments.length) return y;
+        y = v;
+        return lineVariable;
+    };
+
+    lineVariable.w = function(v) {
+        if(!arguments.length) return w;
+        w = v;
+        return lineVariable;
+    };
+
+    lineVariable.interpolate = function(v) {
+        if (!arguments.length) return intpol;
+        intpol = v;
+        return lineVariable;
+    };
+
+    lineVariable.tension = function(v) {
+        if (!arguments.length) return t;
+        t = v;
+        return lineVariable;
+    };
+
+    return lineVariable;
+};
+
+function d3_svg_lineVariablePoints(self, d, x, y, w, intpol, t) {
+    var spinePoints = [],
+        points = [],
+        tmpStack = [],
+        i = -1,
+        n = d.length,
+        fx = typeof x === "function",
+        fy = typeof y === "function",
+        fw = typeof w === "function",
+        line = d3.svg.line().interpolate(intpol).tension(t),
+        value;
+
+    if(fx && fy) {
+        while(++i < n) spinePoints.push([
+              x.call(self, value = d[i], i),
+              y.call(self, value, i)
+        ]);
+    } else if(fx) {
+        while(++i < n) spinePoints.push([x.call(self, d[i], i), y]);
+    } else if(fy) {
+        while(++i < n) spinePoints.push([x, y.call(self, d[i], i)]);
+    } else {
+        while(++i < n) spinePoints.push([x, y]);
+    }
+
+    for(i = 0; i < n; i++) {
+        var thisx = spinePoints[i][0],
+            thisy = spinePoints[i][1],
+            width = fw ? w.call(self, d[i], i) : w,
+            aleft = Math.PI, aright = 0;
+        if(i > 0) {
+            var dx = thisx - spinePoints[i-1][0],
+                dy = thisy - spinePoints[i-1][1];
+            aleft = Math.PI - Math.atan(dy/dx);
+        }
+        if(i < n-1) {
+            var dx = spinePoints[i+1][0] - thisx,
+                dy = thisy - spinePoints[i+1][1];
+            aright = Math.atan(dy/dx);
+        }
+        var gamma = aleft - aright,
+            diff = width/2 / Math.sin(gamma/2),
+            aup = aright + gamma/2,
+            adown = aup - Math.PI,
+            dxup = diff * Math.cos(aup),
+            dyup = diff * Math.sin(aup),
+            dxdown = diff * Math.cos(adown),
+            dydown = diff * Math.sin(adown);
+        points.push([thisx + dxup, thisy - dyup]);
+        tmpStack.push([thisx + dxdown, thisy - dydown]);
+    }
+    var line0 = line(points),
+        // change moveto to lineto as we are continuing the line
+        line1 = line(tmpStack.reverse()).replace("M", "L");
+
+    return line0 + line1;
+}

--- a/src/svg/line-variable.js
+++ b/src/svg/line-variable.js
@@ -80,12 +80,12 @@ function d3_svg_lineVariablePoints(self, d, x, y, w, intpol, t) {
         if(i > 0) {
             var dx = thisx - spinePoints[i-1][0],
                 dy = thisy - spinePoints[i-1][1];
-            aleft = Math.PI - Math.atan(dy/dx);
+            aleft = Math.PI - Math.atan2(dy, dx);
         }
         if(i < n-1) {
             var dx = spinePoints[i+1][0] - thisx,
                 dy = thisy - spinePoints[i+1][1];
-            aright = Math.atan(dy/dx);
+            aright = Math.atan2(dy, dx);
         }
         var gamma = aleft - aright,
             diff = width/2 / Math.sin(gamma/2),

--- a/test/svg/line-variable-test.js
+++ b/test/svg/line-variable-test.js
@@ -1,0 +1,44 @@
+require("../env");
+require("../../d3");
+
+var vows = require("vows"),
+    assert = require("assert");
+
+var suite = vows.describe("d3.svg.line.variable");
+
+suite.addBatch({
+  "line.variable": {
+    topic: function() {
+      return d3.svg.line.variable;
+    },
+
+    "w defaults to 5": function(line) {
+      var l = line();
+      assert.pathEqual(l([[0, 5], [1, 5]]), "M0,2.5L1,2.5L1,7.5L0,7.5Z");
+      assert.equal(l.w(), 5);
+    },
+    "w can be defined as a constant": function(line) {
+      var l = line().w(0);
+      assert.pathEqual(l([[0, 5], [1, 5]]), "M0,5L1,5L1,5L0,5Z");
+      assert.equal(l.w(), 0);
+    },
+    "w can be defined as a function": function(line) {
+      var l = line().w(function(d) { return 3; });
+      assert.pathEqual(l([[0, 5], [1, 5]]), "M0,3.5L1,3.5L1,6.5L0,6.5Z");
+    },
+
+    "interpolate defaults to linear": function(line) {
+      assert.equal(line().interpolate(), "linear");
+    },
+
+    "tension defaults to .7": function(line) {
+      assert.equal(line().tension(), .7);
+    },
+
+    "returns null if input points array is empty": function(line) {
+      assert.isNull(line()([]));
+    }
+  }
+});
+
+suite.export(module);


### PR DESCRIPTION
Simulates variable width lines by drawing and connecting two boundary lines. Can be used in much the same way as d3.svg.line, except that the "fill" attribute does what the "stroke" attribute does for normal lines.

I suppose wrappers could be added to make it behave exactly like d3.svg.line (i.e. intercept .attr calls), but I think explaining how it's done in the documentation would be a better option that would offer people more flexibility.

Example at http://bl.ocks.org/1642835