### PR TITLE
Fixed force layout .drag / .px and .py errors

### DIFF
--- a/src/layout/force.js
+++ b/src/layout/force.js
@@ -56,12 +56,8 @@ d3.layout.force = function() {
         x, // x-distance
         y; // y-distance
 
-    // save previous values
-    for (i = 0; i < n; ++i) {
-      o = nodes[i];
-      o.px = o.x;
-      o.py = o.y;
-    }
+    // note: .px and .py are modified to accumulate forces, which are then
+    // applied to .x and .y at the end.
 
     // gauss-seidel relaxation for links
     for (i = 0; i < m; ++i) {
@@ -74,10 +70,10 @@ d3.layout.force = function() {
         l = alpha * strengths[i] * ((l = Math.sqrt(l)) - distances[i]) / l;
         x *= l;
         y *= l;
-        t.x -= x * (k = s.weight / (t.weight + s.weight));
-        t.y -= y * k;
-        s.x += x * (k = 1 - k);
-        s.y += y * k;
+        t.px += x * (k = s.weight / (t.weight + s.weight));
+        t.py += y * k;
+        s.px -= x * (k = 1 - k);
+        s.py -= y * k;
       }
     }
 
@@ -87,8 +83,8 @@ d3.layout.force = function() {
       y = size[1] / 2;
       i = -1; if (k) while (++i < n) {
         o = nodes[i];
-        o.x += (x - o.x) * k;
-        o.y += (y - o.y) * k;
+        o.px -= (x - o.x) * k;
+        o.py -= (y - o.y) * k;
       }
     }
 
@@ -106,8 +102,8 @@ d3.layout.force = function() {
     i = -1; while (++i < n) {
       o = nodes[i];
       if (o.fixed) {
-        o.x = o.px;
-        o.y = o.py;
+        o.px = o.x;
+        o.py = o.y;
       } else {
         o.x -= (o.px - (o.px = o.x)) * friction;
         o.y -= (o.py - (o.py = o.y)) * friction;


### PR DESCRIPTION
Previous position values (.px/.py) were being set to an intermediate value in tick() processing, causing jumping and drag errors. Only shows up in high-movement graphs; slightly visible in this example: http://bl.ocks.org/1062383 (mouse over pieces and watch the stutter as the pieces "jump" a bit) 

Since o.x and o.y are updated several times (to intermediate values) throughout tick(), we have to capture
.px and .py at the beginning of the function, rather than just before we apply friction to the updated .x and .y values. As a side-effect, the drag code had to be updated to directly modify .x and .y rather than .px and .py.
