### PR TITLE
add option to arrange axis labels automatically

### DIFF
--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -1,6 +1,7 @@
 d3.svg.axis = function() {
   var scale = d3.scale.linear(),
       orient = "bottom",
+      arrange = false,
       tickMajorSize = 6,
       tickMinorSize = 6,
       tickEndSize = 6,
@@ -57,6 +58,7 @@ d3.svg.axis = function() {
       this.__chart__ = scale1;
 
       tickEnter.append("line").attr("class", "tick");
+      tickEnter.append("line").attr("class", "tickPointer");
       tickEnter.append("text");
       tickUpdate.select("text").text(tickFormat);
 
@@ -65,9 +67,11 @@ d3.svg.axis = function() {
           tickTransform = d3_svg_axisX;
           subtickEnter.attr("y2", tickMinorSize);
           subtickUpdate.attr("x2", 0).attr("y2", tickMinorSize);
-          tickEnter.select("line").attr("y2", tickMajorSize);
+          tickEnter.select("line.tick").attr("y2", tickMajorSize);
+          tickEnter.select("line.tickPointer").attr("y1", tickMajorSize).attr("y2", tickMajorSize);
           tickEnter.select("text").attr("y", Math.max(tickMajorSize, 0) + tickPadding);
-          tickUpdate.select("line").attr("x2", 0).attr("y2", tickMajorSize);
+          tickUpdate.select("line.tick").attr("x2", 0).attr("y2", tickMajorSize);
+          tickUpdate.select("line.tickPointer").attr("x2", 0).attr("y2", tickMajorSize);
           tickUpdate.select("text").attr("x", 0).attr("y", Math.max(tickMajorSize, 0) + tickPadding).attr("dy", ".71em").attr("text-anchor", "middle");
           pathUpdate.attr("d", "M" + range[0] + "," + tickEndSize + "V0H" + range[1] + "V" + tickEndSize);
           break;
@@ -76,9 +80,11 @@ d3.svg.axis = function() {
           tickTransform = d3_svg_axisX;
           subtickEnter.attr("y2", -tickMinorSize);
           subtickUpdate.attr("x2", 0).attr("y2", -tickMinorSize);
-          tickEnter.select("line").attr("y2", -tickMajorSize);
+          tickEnter.select("line.tick").attr("y2", -tickMajorSize);
+          tickEnter.select("line.tickPointer").attr("y1", -tickMajorSize).attr("y2", -tickMajorSize);
           tickEnter.select("text").attr("y", -(Math.max(tickMajorSize, 0) + tickPadding));
-          tickUpdate.select("line").attr("x2", 0).attr("y2", -tickMajorSize);
+          tickUpdate.select("line.tick").attr("x2", 0).attr("y2", -tickMajorSize);
+          tickUpdate.select("line.tickPointer").attr("x2", 0).attr("y2", -tickMajorSize);
           tickUpdate.select("text").attr("x", 0).attr("y", -(Math.max(tickMajorSize, 0) + tickPadding)).attr("dy", "0em").attr("text-anchor", "middle");
           pathUpdate.attr("d", "M" + range[0] + "," + -tickEndSize + "V0H" + range[1] + "V" + -tickEndSize);
           break;
@@ -87,9 +93,11 @@ d3.svg.axis = function() {
           tickTransform = d3_svg_axisY;
           subtickEnter.attr("x2", -tickMinorSize);
           subtickUpdate.attr("x2", -tickMinorSize).attr("y2", 0);
-          tickEnter.select("line").attr("x2", -tickMajorSize);
+          tickEnter.select("line.tick").attr("x2", -tickMajorSize);
+          tickEnter.select("line.tickPointer").attr("x1", -tickMajorSize).attr("x2", -tickMajorSize);
           tickEnter.select("text").attr("x", -(Math.max(tickMajorSize, 0) + tickPadding));
-          tickUpdate.select("line").attr("x2", -tickMajorSize).attr("y2", 0);
+          tickUpdate.select("line.tick").attr("x2", -tickMajorSize).attr("y2", 0);
+          tickUpdate.select("line.tickPointer").attr("x2", -tickMajorSize).attr("y2", 0);
           tickUpdate.select("text").attr("x", -(Math.max(tickMajorSize, 0) + tickPadding)).attr("y", 0).attr("dy", ".32em").attr("text-anchor", "end");
           pathUpdate.attr("d", "M" + -tickEndSize + "," + range[0] + "H0V" + range[1] + "H" + -tickEndSize);
           break;
@@ -98,9 +106,11 @@ d3.svg.axis = function() {
           tickTransform = d3_svg_axisY;
           subtickEnter.attr("x2", tickMinorSize);
           subtickUpdate.attr("x2", tickMinorSize).attr("y2", 0);
-          tickEnter.select("line").attr("x2", tickMajorSize);
+          tickEnter.select("line.tick").attr("x2", tickMajorSize);
+          tickEnter.select("line.tickPointer").attr("x1", tickMajorSize).attr("x2", tickMajorSize);
           tickEnter.select("text").attr("x", Math.max(tickMajorSize, 0) + tickPadding);
-          tickUpdate.select("line").attr("x2", tickMajorSize).attr("y2", 0);
+          tickUpdate.select("line.tick").attr("x2", tickMajorSize).attr("y2", 0);
+          tickUpdate.select("line.tickPointer").attr("x2", tickMajorSize).attr("y2", 0);
           tickUpdate.select("text").attr("x", Math.max(tickMajorSize, 0) + tickPadding).attr("y", 0).attr("dy", ".32em").attr("text-anchor", "start");
           pathUpdate.attr("d", "M" + tickEndSize + "," + range[0] + "H0V" + range[1] + "H" + tickEndSize);
           break;
@@ -111,12 +121,12 @@ d3.svg.axis = function() {
       // - enter new ticks from the old scale
       // - exit old ticks to the new scale
       if (scale.ticks) {
-        tickEnter.call(tickTransform, scale0);
-        tickUpdate.call(tickTransform, scale1);
-        tickExit.call(tickTransform, scale1);
-        subtickEnter.call(tickTransform, scale0);
-        subtickUpdate.call(tickTransform, scale1);
-        subtickExit.call(tickTransform, scale1);
+        tickEnter.call(tickTransform, scale0, arrange);
+        tickUpdate.call(tickTransform, scale1, arrange);
+        tickExit.call(tickTransform, scale1, arrange);
+        subtickEnter.call(tickTransform, scale0, arrange);
+        subtickUpdate.call(tickTransform, scale1, arrange);
+        subtickExit.call(tickTransform, scale1, arrange);
       }
 
       // For ordinal scales:
@@ -125,8 +135,8 @@ d3.svg.axis = function() {
       // Therefore, we only need to transition updating ticks.
       else {
         var dx = scale1.rangeBand() / 2, x = function(d) { return scale1(d) + dx; };
-        tickEnter.call(tickTransform, x);
-        tickUpdate.call(tickTransform, x);
+        tickEnter.call(tickTransform, x, arrange);
+        tickUpdate.call(tickTransform, x, arrange);
       }
     });
   }
@@ -176,14 +186,71 @@ d3.svg.axis = function() {
     return axis;
   };
 
+  axis.arrange = function(b) {
+    if (!arguments.length) return arrange;
+    arrange = b;
+    return axis;
+  };
+
   return axis;
 };
 
-function d3_svg_axisX(selection, x) {
+function adjustPositions(poss, dimens, space) {
+  var done = false;
+  while(!done) {
+    done = true;
+    for(var i = 0; i < poss.length-1; i++) {
+      var overlap = poss[i+1] - poss[i] - (dimens[i]/2 + dimens[i+1]/2) - space;
+      if(overlap < -1e-10) {
+        poss[i] += overlap/2;
+        poss[i+1] -= overlap/2;
+        done = false;
+      }
+    }
+  }
+}
+
+function d3_svg_axisX(selection, x, arrange) {
+  if(arrange) {
+    var xs = [], widths = [];
+    selection.each(function(d, i) { xs.push(x(d)); });
+    selection.selectAll("text").each(function(d, i) {
+      if(typeof this.getBBox === 'function') {
+        widths.push(this.getBBox().width);
+      } else {
+        console.error("Cannot determine bounding box to arrange axis.");
+        return;
+      }
+    });
+    adjustPositions(xs, widths, 3);
+    selection.each(function(d, i) {
+      var diff = xs[i++] - x(d);
+      d3.select(this).select("text").attr("x", diff);
+      d3.select(this).select("line.tickPointer").attr("x2", diff);
+    });
+  }
   selection.attr("transform", function(d) { return "translate(" + x(d) + ",0)"; });
 }
 
-function d3_svg_axisY(selection, y) {
+function d3_svg_axisY(selection, y, arrange) {
+  if(arrange) {
+    var ys = [], heights = [];
+    selection.each(function(d, i) { ys.push(y(d)); });
+    selection.selectAll("text").each(function(d, i) {
+      if(typeof this.getBBox === 'function') {
+        heights.push(this.getBBox().height);
+      } else {
+        console.error("Cannot determine bounding box to arrange axis.");
+        return;
+      }
+    });
+    adjustPositions(ys, heights, 0);
+    selection.each(function(d, i) {
+      var diff = ys[i++] - y(d);
+      d3.select(this).select("text").attr("y", diff);
+      d3.select(this).select("line.tickPointer").attr("y2", diff);
+    });
+  }
   selection.attr("transform", function(d) { return "translate(0," + y(d) + ")"; });
 }
 

--- a/test/svg/axis-test.js
+++ b/test/svg/axis-test.js
@@ -352,6 +352,19 @@ suite.addBatch({
           assert.equal(t.select("text").text(), tickFormat(ticks[i]));
         });
       }
+    },
+
+    "arrange": {
+      "defaults false": function(axis) {
+        var a = axis();
+        assert.equal(a.arrange(), false);
+      },
+      "adds tickPointer": function(axis) {
+        var a = axis().arrange(true),
+            g = d3.select("body").html("").append("svg:g").call(a),
+            tick = g.select("g:nth-child(1)");
+        assert.isFalse(tick.select("line.tickPointer").empty());
+      }
     }
   }
 });


### PR DESCRIPTION
Introduces the "arrange" option for the axis components. If set to true and the
axis labels overlap, it will use a simple linear probing algorithm to shift the
labels such that they do not overlap anymore. Adds an element line.tickPointer
that will point from the axis tick to the shifted label. Also adds the class
tick to the axis tick line to be able to distinguish the two.

This is a preliminary implementation that doesn't allow a lot of customisation
and provides only the most basic functionality. The new option defaults to
false, in which case there is no change to the previous behaviour.

Example at http://bl.ocks.org/1678215

Not particularly useful in this context, more so in conjunction with https://github.com/mbostock/d3/pull/326