### PR TITLE
Make the "auto-scaling" time formats use 24-hour hours

### DIFF
--- a/d3.time.js
+++ b/d3.time.js
@@ -653,7 +653,7 @@ var d3_time_scaleLocalFormats = [
   [d3.time.format("%B"), function(d) { return d.getMonth(); }],
   [d3.time.format("%b %d"), function(d) { return d.getDate() != 1; }],
   [d3.time.format("%a %d"), function(d) { return d.getDay() && d.getDate() != 1; }],
-  [d3.time.format("%I %p"), function(d) { return d.getHours(); }],
+  [d3.time.format("%H"), function(d) { return d.getHours(); }],
   [d3.time.format("%I:%M"), function(d) { return d.getMinutes(); }],
   [d3.time.format(":%S"), function(d) { return d.getSeconds(); }],
   [d3.time.format(".%L"), function(d) { return d.getMilliseconds(); }]
@@ -695,7 +695,7 @@ var d3_time_scaleUTCFormats = [
   [d3.time.format.utc("%B"), function(d) { return d.getUTCMonth(); }],
   [d3.time.format.utc("%b %d"), function(d) { return d.getUTCDate() != 1; }],
   [d3.time.format.utc("%a %d"), function(d) { return d.getUTCDay() && d.getUTCDate() != 1; }],
-  [d3.time.format.utc("%I %p"), function(d) { return d.getUTCHours(); }],
+  [d3.time.format.utc("%H"), function(d) { return d.getUTCHours(); }],
   [d3.time.format.utc("%I:%M"), function(d) { return d.getUTCMinutes(); }],
   [d3.time.format.utc(":%S"), function(d) { return d.getUTCSeconds(); }],
   [d3.time.format.utc(".%L"), function(d) { return d.getUTCMilliseconds(); }]


### PR DESCRIPTION
I'm not sure if it's worth making this an option; but if it's not then 24-hours really are more universally useful than 12-hours + am/pm.  :-)
