### PR TITLE
Add index.js for easier usage within Node.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,26 @@
+var self = this,
+    globals = ["document", "window", "navigator", "CSSStyleDeclaration", "d3"],
+    globalValues = {};
+
+globals.forEach(function(global) {
+  if (global in self) globalValues[global] = self[global];
+});
+
+document = require("jsdom").jsdom("<html><head></head><body></body></html>");
+window = document.createWindow();
+navigator = window.navigator;
+CSSStyleDeclaration = window.CSSStyleDeclaration;
+
+require("./d3");
+require("./d3.csv");
+require("./d3.geo");
+require("./d3.geom");
+require("./d3.layout");
+require("./d3.time");
+
+module.exports = d3;
+
+globals.forEach(function(global) {
+  if (global in globalValues) self[global] = globalValues[global];
+  else delete self[global];
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "type": "git",
     "url": "http://github.com/mbostock/d3.git"
   },
-  "main": "d3.js",
+  "main": "index.js",
   "dependencies": {
     "jsdom": "0.2.10"
   },


### PR DESCRIPTION
This allows you to require("d3") with no additional dependencies, and without
polluting the global namespace. Fixes #475.
