### PR TITLE
Add PivotGraph (rollup) layout example.

### DIFF
--- a/examples/rollup/rollup.html
+++ b/examples/rollup/rollup.html
@@ -80,8 +80,8 @@ vis.selectAll("circle")
     .data(g.nodes)
   .enter().append("circle")
     .attr("r", function(d) { return Math.sqrt(d.nodes.length * 20); })
-    .attr("cx", function(d) { return d.y; })
-    .attr("cy", function(d) { return d.x; });
+    .attr("cx", function(d) { return d.x; })
+    .attr("cy", function(d) { return d.y; });
 
 vis.selectAll("text.x")
     .data(x.domain())


### PR DESCRIPTION
This is ported from the Protovis implementation, [pv.Layout.Rollup](http://mbostock.github.com/protovis/jsdoc/symbols/pv.Layout.Rollup.html). The only difference is that the rollup nodes are not instances of any original nodes (Protovis used pv.extend).  Users are expected to use the "x" and "y" properties of the rollup node, or alternatively the "rolled up" nodes can be retrieved via the "nodes" property.
