### PR TITLE
Generalize gravity to a field in force layout

### DIFF
--- a/src/layout/force.js
+++ b/src/layout/force.js
@@ -43,6 +43,12 @@ d3.layout.force = function() {
     };
   }
 
+  field = function(x, y, w, h) {
+      return {
+          x: w/2.-x,
+          y: h/2.-y,
+      };
+  };
   function tick() {
     // simulated annealing, basically
     if ((alpha *= .99) < .005) return true;
@@ -77,14 +83,13 @@ d3.layout.force = function() {
       }
     }
 
-    // apply gravity forces
+    // apply field forces
     if (k = alpha * gravity) {
-      x = size[0] / 2;
-      y = size[1] / 2;
-      i = -1; if (k) while (++i < n) {
+      for (i = 0; i < n; ++i) {
         o = nodes[i];
-        o.x += (x - o.x) * k;
-        o.y += (y - o.y) * k;
+        f = field(o.x, o.y, size[0], size[1]);
+        o.x += f.x * k;
+        o.y += f.y * k;
       }
     }
 
@@ -163,6 +168,12 @@ d3.layout.force = function() {
     gravity = x;
     return force;
   };
+
+  force.field = function(f) {
+    if (!arguments.length) return field;
+    field = f;
+    return force;
+  }
 
   force.theta = function(x) {
     if (!arguments.length) return theta;


### PR DESCRIPTION
This can be a flexible tool for certain effects. In my case, it is
having a single element in the centre (achieved with `e.fixed = 1`),
whilst everybody else tries to be a bit far away, but not too far away.
So, I have a moat field where there is centrifugal force if you are more
than R away from centre, and centripetal force if you are less than R.

As a special case (and the default), this is the traditional gravity
field.

Implementation is simple too.
