### PR TITLE
Expose d3_selection_enterPrototype for better extensibility

### DIFF
--- a/src/core/selection-enter.js
+++ b/src/core/selection-enter.js
@@ -5,6 +5,9 @@ function d3_selection_enter(selection) {
 
 var d3_selection_enterPrototype = [];
 
+d3.selection.enter = d3_selection_enter;
+d3.selection.enter.prototype = d3_selection_enterPrototype;
+
 d3_selection_enterPrototype.append = d3_selectionPrototype.append;
 d3_selection_enterPrototype.insert = d3_selectionPrototype.insert;
 d3_selection_enterPrototype.empty = d3_selectionPrototype.empty;


### PR DESCRIPTION
In order to make some d3 plugins I came to extend `d3_selectionPrototype` which was fortunately available as `d3.selection.prototype`.

But, unfortunately, I discovered that `d3_selection_enterPrototype` wasn't available as a _public API_, so here I'm just proposing to expose `d3_selection_enter` as `d3.selection.enter` and to put `d3_selection_enterPrototype` as its prototype `d3.selection.enter.prototype`.

Btw, I think extensibility deserves better doc, will probably do another pull request about it next time.

Also, as I just wanted to make a one-feature pull request I didn't include this but I think it would probably be nice to have some kind of helper like :

```
d3.selection.extend = function(name, method) {
  d3.selection[name] = d3.selection.enter[name] = method;
  return d3.selection;
};
```

What do you think ?
