### PR TITLE
update to latest jsdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "jsdom": "0.2.10"
+    "jsdom": "0.2.12"
   },
   "devDependencies": {
     "uglify-js": "1.2.3",


### PR DESCRIPTION
The update is to get the most recent version of contextify
which is a dependency of jsdom. Previous versions of 
contextify always generate a 64 library module. v0.6.11 of
node on macos is a 32-bit ARCH. The latest version of 
contextify  builds an ARCH that matches node NOT the arch
of the system.

See: https://github.com/brianmcd/contextify/issues/19
