### PR TITLE
fix typo on path

### DIFF
--- a/examples/histogram/histogram.html
+++ b/examples/histogram/histogram.html
@@ -18,7 +18,7 @@
 
 </style>
 <body>
-<script src="d3.v2.js"></script>
+<script src="../../d3.v2.js"></script>
 <script src="histogram-chart.js"></script>
 <script>
 


### PR DESCRIPTION
There's a missing "../../" on the `<script>` tag. This patch makes it consistent with the other examples (and makes the example work with a webserver running on d3/)
