### PR TITLE
Added ability to specify chords with explicit relationships instead of a matrix.

### DIFF
--- a/d3.v2.js
+++ b/d3.v2.js
@@ -4943,6 +4943,7 @@ d3.layout.chord = function() {
       chords,
       groups,
       matrix,
+      relationships, // [{ source: int, target: int, value: dbl }]
       n,
       padding = 0,
       sortGroups,
@@ -4963,84 +4964,166 @@ d3.layout.chord = function() {
     chords = [];
     groups = [];
 
-    // Compute the sum.
-    k = 0, i = -1; while (++i < n) {
-      x = 0, j = -1; while (++j < n) {
-        x += matrix[i][j];
+    if (matrix) {
+      // Compute the sum.
+      k = 0, i = -1; while (++i < n) {
+        x = 0, j = -1; while (++j < n) {
+          x += matrix[i][j];
+        }
+        groupSums.push(x);
+        subgroupIndex.push(d3.range(n));
+        k += x;
       }
-      groupSums.push(x);
-      subgroupIndex.push(d3.range(n));
-      k += x;
-    }
 
-    // Sort groups…
-    if (sortGroups) {
-      groupIndex.sort(function(a, b) {
-        return sortGroups(groupSums[a], groupSums[b]);
-      });
-    }
-
-    // Sort subgroups…
-    if (sortSubgroups) {
-      subgroupIndex.forEach(function(d, i) {
-        d.sort(function(a, b) {
-          return sortSubgroups(matrix[i][a], matrix[i][b]);
+      // Sort groups…
+      if (sortGroups) {
+        groupIndex.sort(function(a, b) {
+          return sortGroups(groupSums[a], groupSums[b]);
         });
-      });
-    }
-
-    // Convert the sum to scaling factor for [0, 2pi].
-    // TODO Allow start and end angle to be specified.
-    // TODO Allow padding to be specified as percentage?
-    k = (2 * Math.PI - padding * n) / k;
-
-    // Compute the start and end angle for each group and subgroup.
-    // Note: Opera has a bug reordering object literal properties!
-    x = 0, i = -1; while (++i < n) {
-      x0 = x, j = -1; while (++j < n) {
-        var di = groupIndex[i],
-            dj = subgroupIndex[di][j],
-            v = matrix[di][dj],
-            a0 = x,
-            a1 = x += v * k;
-        subgroups[di + "-" + dj] = {
-          index: di,
-          subindex: dj,
-          startAngle: a0,
-          endAngle: a1,
-          value: v
-        };
       }
-      groups.push({
-        index: di,
-        startAngle: x0,
-        endAngle: x,
-        value: (x - x0) / k
-      });
-      x += padding;
-    }
 
-    // Generate chords for each (non-empty) subgroup-subgroup link.
-    i = -1; while (++i < n) {
-      j = i - 1; while (++j < n) {
-        var source = subgroups[i + "-" + j],
-            target = subgroups[j + "-" + i];
-        if (source.value || target.value) {
-          chords.push(source.value < target.value
-              ? {source: target, target: source}
-              : {source: source, target: target});
+      // Sort subgroups…
+      if (sortSubgroups) {
+        subgroupIndex.forEach(function(d, i) {
+          d.sort(function(a, b) {
+            return sortSubgroups(matrix[i][a], matrix[i][b]);
+          });
+        });
+      }
+
+      // Convert the sum to scaling factor for [0, 2pi].
+      // TODO Allow start and end angle to be specified.
+      // TODO Allow padding to be specified as percentage?
+      k = (2 * Math.PI - padding * n) / k;
+
+      // Compute the start and end angle for each group and subgroup.
+      // Note: Opera has a bug reordering object literal properties!
+      x = 0, i = -1; while (++i < n) {
+        x0 = x, j = -1; while (++j < n) {
+          var di = groupIndex[i],
+              dj = subgroupIndex[di][j],
+              v = matrix[di][dj],
+              a0 = x,
+              a1 = x += v * k;
+          subgroups[di + "-" + dj] = {
+            index: di,
+            subindex: dj,
+            startAngle: a0,
+            endAngle: a1,
+            value: v
+          };
+        }
+        groups.push({
+          index: di,
+          startAngle: x0,
+          endAngle: x,
+          value: (x - x0) / k
+        });
+        x += padding;
+      }
+
+      // Generate chords for each (non-empty) subgroup-subgroup link.
+      i = -1; while (++i < n) {
+        j = i - 1; while (++j < n) {
+          var source = subgroups[i + "-" + j],
+              target = subgroups[j + "-" + i];
+          if (source.value || target.value) {
+            chords.push(source.value < target.value
+                ? {source: target, target: source}
+                : {source: source, target: target});
+          }
         }
       }
-    }
 
-    if (sortChords) resort();
+      if (sortChords) resort();
+    }
+    // Otherwise, use the relationships.
+    else if (relationships) {
+      // Calculate group sums.
+      k = 0;
+      relationships.forEach(function(rel) {
+        x = rel.value;
+        groupSums[rel.source] = groupSums[rel.source] || 0 + x;
+        k += x;
+        if (rel.source !== rel.target) {
+          k += x;
+          groupSums[rel.target] = groupSums[rel.target] || 0 + x;
+        }
+      });
+
+      // Only add padding for groups with a value.
+      var n0 = 0;
+      groupSums.forEach(function(sum) {
+        if (sum) n0++;
+      });
+
+      // Convert the sum to scaling factor for [0, 2pi].
+      // TODO Allow start and end angle to be specified.
+      // TODO Allow padding to be specified as percentage?
+      k = (2 * Math.PI - padding * n0) / k;
+
+      // Calculate groups and chords.
+      // For i = 0 to n, loop through all relationships in order.  Add each relationship value to the group; 
+      // add any chords with a value on the spot.  (Note that we're using 'subgroups' differently here than
+      // above; here it is used to maintain a list of chords indexed by "source-target").
+      var gp, chd;
+      x = 0; i = -1; while (++i < n) {
+        gp = { index: i, startAngle: x, value: 0 };
+        // First check for relationships where i is the source, as they should come first.
+        j = 0;
+        relationships.forEach(function(rel) {
+          if (rel.source !== i || rel.value === 0) return;
+          gp.value += rel.value;
+          chd = subgroups[i + '-' + rel.target] || (subgroups[i + '-' + rel.target] = {});
+          chd.source = {
+            index: i,
+            subindex: j,
+            startAngle: x,
+            endAngle: x += (rel.value * k),
+            value: rel.value
+          };
+          // Special handling for self-targetting relationships.
+          if (rel.target === i) chd.target = chd.source;
+          j++;
+        });
+        // Then check for relationships where i is the target.
+        relationships.forEach(function(rel) {
+          if (rel.source === i) return; // This special case was handled above.
+          if (rel.target !== i || rel.value === 0) return;
+          gp.value += rel.value;
+          chd = subgroups[rel.source + '-' + i] || (subgroups[rel.source + '-' + i] = {});
+          chd.target = {
+            index: i,
+            subindex: j,
+            startAngle: x,
+            endAngle: x += (rel.value * k),
+            value: rel.value
+          };
+          j++;
+        });
+        // If the group value has increased beyond zero, calculate endAngle and add to groups.
+        if (!gp.value) continue;
+        gp.endAngle = x;
+        groups.push(gp);
+        x += padding;
+      }
+
+      // Move chords from subgroups object to chords array.
+      i = -1; while(++i < n) {
+        j = -1; while(++j < n) {
+          gp = subgroups[i + '-' + j]
+          if (gp) chords.push(gp)
+        }
+      }
+
+    }
   }
 
   function resort() {
     chords.sort(function(a, b) {
       return sortChords(
-          (a.source.value + a.target.value) / 2,
-          (b.source.value + b.target.value) / 2);
+        (a.source.value + a.target.value) / 2,
+        (b.source.value + b.target.value) / 2);
     });
   }
 
@@ -5050,6 +5133,24 @@ d3.layout.chord = function() {
     chords = groups = null;
     return chord;
   };
+
+  chord.relationships = function(x) {
+    if (!arguments.length) return relationships;
+    relationships = x;
+    chords = groups = null;
+    relationships.forEach(function(rel) {
+      n = Math.max(n || 0, rel.source + 1, rel.target + 1); // Note that n is 1-based.
+    });
+    return chord;
+  };
+
+  chord.addRelationship = function(sourceIndex, targetIndex, value) {
+    relationships = relationships || [];
+    relationships.push({source: sourceIndex, target: targetIndex, value: value});
+    chords = groups = null;
+    n = Math.max(n || 0, sourceIndex + 1, targetIndex + 1); // Note that n is 1-based.
+    return chord;
+  }
 
   chord.padding = function(x) {
     if (!arguments.length) return padding;


### PR DESCRIPTION
Hi,

I wanted the ability to specify chord data with a simple

{
   source: 0,
   target: 2,
   value: 45,372
}

kind of relationship object.  This also allows explicit declaration of which is the source and which is the target.  (When using a matrix, whichever number is first, or larger, wins.)

I added two new methods to d3.layout.chord:

.relationships(x) 
 - gets or sets the relationships array.

.addRelationship(sourceIndex, targetIndex, value)
 - pushes an individual relationship onto the relationships array.

I then added code to that closure's relayout() function to use the relationships array to populate the chords and groups arrays.

I've got a sample reworking of the hair-color example chord with the correct dominant hair color highlighted.  I'm having git issues though, and am unable to push the new files.  Happy to send them offline on request.

Feedback is of course appreciated.

Cheers,
Dave