### PR TITLE
Add browserify compatibility

### DIFF
--- a/index-browserify.js
+++ b/index-browserify.js
@@ -1,0 +1,2 @@
+require("./d3.v2");
+module.exports = d3;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "url": "http://github.com/mbostock/d3.git"
   },
   "main": "index.js",
+  "browserify" : "index-browserify.js",
   "dependencies": {
     "jsdom": "0.2.14",
     "sizzle": "1.1.x"


### PR DESCRIPTION
Hi,

These 3 little lines make d3 compatible with [browserify](https://github.com/substack/node-browserify) and thus allow developers like me to easily include d3 – or any browserify-compatible module requiring d3 (like cubism.. :D) – in their browserify bundles. Great !

Please merge if OK !
