### PR TITLE
add start and end parent != undefined in d3_layout_bundlePath while

### DIFF
--- a/d3.v2.js
+++ b/d3.v2.js
@@ -4938,12 +4938,12 @@ function d3_layout_bundlePath(link) {
       end = link.target,
       lca = d3_layout_bundleLeastCommonAncestor(start, end),
       points = [start];
-  while (start !== lca) {
+  while (start !== lca && start.parent != undefined) {
     start = start.parent;
     points.push(start);
   }
   var k = points.length;
-  while (end !== lca) {
+  while (end !== lca && end.parent != undefined) {
     points.splice(k, 0, end);
     end = end.parent;
   }


### PR DESCRIPTION
An undefined import causes a fatal error in the bundle-radial demo.  This commit avoids the error, the ui will go on to draw a line to a blank node.  To recreate initial undefined error add a un-"name"ed node to one of the imports in examples/data/flare-imports.

Thanks for sharing such an awesome tool.
