### PR TITLE
passing object into .attr()

### DIFF
--- a/d3.v2.js
+++ b/d3.v2.js
@@ -2298,11 +2298,12 @@ d3_transitionPrototype.selectAll = function(selector) {
   return d3_transition(subgroups, this.id, this.time).ease(this.ease());
 };
 d3_transitionPrototype.attr = function(name, value) {
+	var ro; 
 	if(typeof(name) == 'object'){
 		for(var k in name){
-			 this.attrTween(k, d3_transitionTween(k, name[k]));
+			ro = this.attrTween(k, d3_transitionTween(k, name[k]));
 		}
-		return;
+		return ro;
 	}
 	return this.attrTween(name, d3_transitionTween(name, value));
 };


### PR DESCRIPTION
normally, the .attr() function forces coders to have quite long strings of .attr(key,value) snippets. 

It would look like:

<pre>
  d3.select('#svg').append('circle').attr('r',50).attr('fill','#fff').attr('stroke','#f00');
</pre>


Changing the function a little bit, it can operate more like the jQuery .css() function. Coders can pass an object of `key : value` pairs that will be looped through and called as a single .attr() command.

the new code looks like

<pre>
  d3.select('#svg').append('circle').attr({
    "r" : 20,
    "fill" : "red",
    "stroke" : "#fff",
  });
</pre>

