### PR TITLE
Fix race condition in transition tests.

### DIFF
--- a/test/core/transition-test.js
+++ b/test/core/transition-test.js
@@ -38,7 +38,7 @@ var suite = vows.describe("transition");
 suite.addBatch({
   "select": require("./transition-test-select"),
   "selectAll": require("./transition-test-selectAll"),
-  "transition": require("./transition-test-transition"),
+  "transition": require("./transition-test-transition")
 });
 
 // Content
@@ -48,13 +48,13 @@ suite.addBatch({
   "style": require("./transition-test-style"),
   "styleTween": require("./transition-test-styleTween"),
   "text": require("./transition-test-text"),
-  "remove": require("./transition-test-remove"),
+  "remove": require("./transition-test-remove")
 });
 
 // Animation
 suite.addBatch({
   "delay": require("./transition-test-delay"),
-  "duration": require("./transition-test-duration"),
+  "duration": require("./transition-test-duration")
 });
 
 // Control


### PR DESCRIPTION
The transition-test-text callback was failing to fire when using the latest Node.js master (joyent/node@82bcdbb8aaa4cf58917dc8d3fd4fcfc272512a2c).  This was most likely due to these tests being run in a different order due to a different object enumeration order.
