### PR TITLE
API inconsistency when using Sizzle causing defect in IE9

### DIFF
--- a/src/core/selection.js
+++ b/src/core/selection.js
@@ -11,7 +11,7 @@ var d3_select = function(s, n) { return n.querySelector(s); },
 
 // Prefer Sizzle, if available.
 if (typeof Sizzle === "function") {
-  d3_select = function(s, n) { return Sizzle(s, n)[0]; };
+  d3_select = function(s, n) { return Sizzle(s, n)[0] || null; };
   d3_selectAll = function(s, n) { return Sizzle.uniqueSort(Sizzle(s, n)); };
   d3_selectMatches = Sizzle.matchesSelector;
 }


### PR DESCRIPTION
When using Sizzle, the API for `d3_select` changes when there is no element to select. When using Sizzle, `undefined` is returned since `[][0] === undefined`. Without Sizzle, `d3_select` returns `null`. This is a problem, because IE9 does not support calling `HTMLElement.insertBefore` (see selection-insert.js) with `undefined` as the second argument; `null` is fine, though.
