### PR TITLE
Fix for Issue #675

### DIFF
--- a/src/core/selection-classed.js
+++ b/src/core/selection-classed.js
@@ -1,5 +1,5 @@
 d3_selectionPrototype.classed = function(name, value) {
-  var names = name.split(d3_selection_classedWhitespace),
+  var names = d3_collapse(name).split(" "),
       n = names.length,
       i = -1;
   if (arguments.length > 1) {
@@ -10,8 +10,6 @@ d3_selectionPrototype.classed = function(name, value) {
     return true;
   }
 };
-
-var d3_selection_classedWhitespace = /\s+/g;
 
 function d3_selection_classed(name, value) {
   var re = new RegExp("(^|\\s+)" + d3.requote(name) + "(\\s+|$)", "g");


### PR DESCRIPTION
Remove spurious whitespace from class name list before splitting to eliminate null strings, which generate an error from classed(value, false).
