### PR TITLE
Fixes custom timezone tests for Node.js 0.8.x.

### DIFF
--- a/test/time/hour-test.js
+++ b/test/time/hour-test.js
@@ -42,14 +42,14 @@ suite.addBatch({
         assert.deepEqual(floor(utc(2011, 10, 06, 09, 01)), utc(2011, 10, 06, 09));
       },
       "NPT": {
-        "observes 15-minute offset": time.zone("Asia/Kathmandu", function(floor) {
+        "observes 15-minute offset": time.zone(345, function(floor) {
           assert.deepEqual(floor(local(2010, 11, 31, 23, 59, 59)), utc(2010, 11, 31, 17, 15));
           assert.deepEqual(floor(local(2011, 00, 01, 00, 00, 00)), utc(2010, 11, 31, 18, 15));
           assert.deepEqual(floor(local(2011, 00, 01, 00, 00, 01)), utc(2010, 11, 31, 18, 15));
         })
       },
       "IST": {
-        "observes 30-minute offset": time.zone("Asia/Calcutta", function(floor) {
+        "observes 30-minute offset": time.zone(330, function(floor) {
           assert.deepEqual(floor(local(2010, 11, 31, 23, 59, 59)), utc(2010, 11, 31, 17, 30));
           assert.deepEqual(floor(local(2011, 00, 01, 00, 00, 00)), utc(2010, 11, 31, 18, 30));
           assert.deepEqual(floor(local(2011, 00, 01, 00, 00, 01)), utc(2010, 11, 31, 18, 30));
@@ -82,14 +82,14 @@ suite.addBatch({
         assert.deepEqual(ceil(utc(2011, 10, 06, 09, 01)), utc(2011, 10, 06, 10));
       },
       "NPT": {
-        "observes 15-minute offset": time.zone("Asia/Kathmandu", function(ceil) {
+        "observes 15-minute offset": time.zone(345, function(ceil) {
           assert.deepEqual(ceil(local(2010, 11, 31, 23, 59, 59)), utc(2010, 11, 31, 18, 15));
           assert.deepEqual(ceil(local(2011, 00, 01, 00, 00, 00)), utc(2010, 11, 31, 18, 15));
           assert.deepEqual(ceil(local(2011, 00, 01, 00, 00, 01)), utc(2010, 11, 31, 19, 15));
         })
       },
       "IST": {
-        "observes 30-minute offset": time.zone("Asia/Calcutta", function(ceil) {
+        "observes 30-minute offset": time.zone(330, function(ceil) {
           assert.deepEqual(ceil(local(2010, 11, 31, 23, 59, 59)), utc(2010, 11, 31, 18, 30));
           assert.deepEqual(ceil(local(2011, 00, 01, 00, 00, 00)), utc(2010, 11, 31, 18, 30));
           assert.deepEqual(ceil(local(2011, 00, 01, 00, 00, 01)), utc(2010, 11, 31, 19, 30));

--- a/test/time/hours-test.js
+++ b/test/time/hours-test.js
@@ -49,7 +49,7 @@ suite.addBatch({
       ]);
     },
     "NPT": {
-      "observes 15-minute offset": tz("Asia/Kathmandu", function(range) {
+      "observes 15-minute offset": time.zone(345, function(range) {
         assert.deepEqual(range(local(2011, 10, 7, 0), local(2011, 10, 7, 3)), [
           utc(2011, 10, 6, 18, 15),
           utc(2011, 10, 6, 19, 15),
@@ -58,7 +58,7 @@ suite.addBatch({
       })
     },
     "IST": {
-      "observes 30-minute offset": tz("Asia/Calcutta", function(range) {
+      "observes 30-minute offset": time.zone(330, function(range) {
         assert.deepEqual(range(local(2011, 10, 7, 0), local(2011, 10, 7, 3)), [
           utc(2011, 10, 6, 18, 30),
           utc(2011, 10, 6, 19, 30),
@@ -108,21 +108,5 @@ suite.addBatch({
     }
   }
 });
-
-function tz(tz, scope) {
-  return function() {
-    var o = process.env.TZ;
-    try {
-      process.env.TZ = tz;
-      new Date(0).toString(); // invalidate node's dst cache
-      new Date().toString();
-      scope.apply(this, arguments);
-    } finally {
-      process.env.TZ = o;
-      new Date(0).toString(); // invalidate node's dst cache
-      new Date().toString();
-    }
-  };
-}
 
 suite.export(module);

--- a/test/time/time.js
+++ b/test/time/time.js
@@ -1,7 +1,9 @@
+var offset = 0;
+
 exports.local = function(year, month, day, hours, minutes, seconds, milliseconds) {
   var date = new Date();
   date.setFullYear(year, month, day);
-  date.setHours(hours || 0, minutes || 0, seconds || 0, milliseconds || 0);
+  date.setHours(hours || 0, offset + (minutes || 0), seconds || 0, milliseconds || 0);
   return date;
 };
 
@@ -12,18 +14,19 @@ exports.utc = function(year, month, day, hours, minutes, seconds, milliseconds) 
   return date;
 };
 
-exports.zone = function(tz, scope) {
+exports.zone = function(tzOffset, scope) {
   return function() {
-    var o = process.env.TZ;
+    var o = Date.prototype.getTimezoneOffset;
     try {
-      process.env.TZ = tz;
-      new Date(0).toString(); // invalidate node's dst cache
-      new Date().toString();
+      // Note: assumes the dates are not in DST.
+      offset = -tzOffset - new Date(0).getTimezoneOffset();
+      Date.prototype.getTimezoneOffset = function() {
+        return offset;
+      };
       scope.apply(this, arguments);
     } finally {
-      process.env.TZ = o;
-      new Date(0).toString(); // invalidate node's dst cache
-      new Date().toString();
+      offset = 0;
+      Date.prototype.getTimezoneOffset = o;
     }
   };
 };


### PR DESCRIPTION
The process.env.TZ trick no longer seems to work. The fix automatically adds an offset to the minutes being set, relative to the current timezone. It assumes that the dates being tested in the scope are not in DST, since the offset is relative to the timezone offset at the epoch.

Fixes #718.
