### PR TITLE
IE9 and CORS (Cross-Origin Resource Sharing)

### DIFF
--- a/d3.v2.js
+++ b/d3.v2.js
@@ -418,17 +418,25 @@
     return n ? Math.round(x * (n = Math.pow(10, n))) / n : Math.round(x);
   };
   d3.xhr = function(url, mime, callback) {
-    var req = new XMLHttpRequest;
-    if (arguments.length < 3) callback = mime, mime = null; else if (mime && req.overrideMimeType) req.overrideMimeType(mime);
-    req.open("GET", url, true);
-    if (mime) req.setRequestHeader("Accept", mime);
-    req.onreadystatechange = function() {
-      if (req.readyState === 4) {
-        var s = req.status;
-        callback(!s && req.response || s >= 200 && s < 300 || s === 304 ? req : null);
-      }
-    };
-    req.send(null);
+	if(window.XDomainRequest && url.indexOf('http://') === 0){
+	  var xdr = new XDomainRequest();
+	  xdr.open("get", url);
+	  xdr.onload = function(){callback(this);}
+	  xdr.onerror = function(){callback(null);}
+	  xdr.send();
+	} else{
+      var req = new XMLHttpRequest;
+      if (arguments.length < 3) callback = mime, mime = null; else if (mime && req.overrideMimeType) req.overrideMimeType(mime);
+      req.open("GET", url, true);
+      if (mime) req.setRequestHeader("Accept", mime);
+      req.onreadystatechange = function() {
+        if (req.readyState === 4) {
+          var s = req.status;
+          callback(!s && req.response || s >= 200 && s < 300 || s === 304 ? req : null);
+        }
+      };
+      req.send(null);
+	}
   };
   d3.text = function(url, mime, callback) {
     function ready(req) {


### PR DESCRIPTION
In an example that I was trying to use, I need to go across domains. CORS works well in all browsers except <= IE9. Since most of the examples will work in IE9, I figured I'd add the XDR code to make it work. It did not add much extra to the code. The reason for the url.indexOf was that if there is no CORS, the XDR will not work. 
