### PR TITLE
Fix use of "dx" in "tree" example.

### DIFF
--- a/ex/tree.js
+++ b/ex/tree.js
@@ -32,9 +32,8 @@ d3.json("../data/flare.json", function(json) {
       .attr("r", 4.5);
 
   node.append("text")
-      .attr("dx", function(d) { return d.x < 180 ? 8 : -8; })
       .attr("dy", ".31em")
       .attr("text-anchor", function(d) { return d.x < 180 ? "start" : "end"; })
-      .attr("transform", function(d) { return d.x < 180 ? null : "rotate(180)"; })
+      .attr("transform", function(d) { return d.x < 180 ? "translate(8)" : "rotate(180)translate(-8)"; })
       .text(function(d) { return d.name; });
 });


### PR DESCRIPTION
See #780.
