### PR TITLE
Adding y1 to default stackOut

### DIFF
--- a/src/layout/stack.js
+++ b/src/layout/stack.js
@@ -94,6 +94,7 @@ function d3_layout_stackY(d) {
 
 function d3_layout_stackOut(d, y0, y) {
   d.y0 = y0;
+  d.y1 = y0+y;
   d.y = y;
 }
 


### PR DESCRIPTION
SVG Rectangles start at top-left corner (x0,y1).  Providing y1 simplifies rendering and should be backwards compatable.