### PR TITLE
Empty default enter() and exit() for all selections (previously undefined)

### DIFF
--- a/src/core/selection.js
+++ b/src/core/selection.js
@@ -1,5 +1,6 @@
 function d3_selection(groups) {
   d3_arraySubclass(groups, d3_selectionPrototype);
+  groups.enter = groups.exit = function() { return d3.select(); };
   return groups;
 }
 


### PR DESCRIPTION
This allows for better consistancy among selection objects, with enter() exit() chains ignored if no new .data() has been defined for the selection.  Should be backwards compatible.
