### PR TITLE
force cluster example: fixed minor hull error ('hulls' --> 'hullset') + ...

### DIFF
--- a/examples/force/force-cluster.html
+++ b/examples/force/force-cluster.html
@@ -12,6 +12,10 @@ body {
 }
 circle.node {
   fill: lightsteelblue;
+  stroke: #555;
+  stroke-width: 3px;
+}
+circle.leaf {
   stroke: #fff;
   stroke-width: 1.5px;
 }
@@ -85,7 +89,8 @@ function network(data, prev, index, expand) {
   // determine nodes
   for (var k=0; k<data.nodes.length; ++k) {
     var n = data.nodes[k],
-        i = index(n);
+        i = index(n),
+        l = gm[i] || (gm[i]=gn[i]) || (gm[i]={group:i, size:0, nodes:[]});
 
     if (expand[i]) {
       // the node should be directly visible
@@ -98,7 +103,6 @@ function network(data, prev, index, expand) {
       }
     } else {
       // the node is part of a collapsed cluster
-      var l = gm[i] || (gm[i]=gn[i]) || (gm[i]={group:i, size:0, nodes:[]});
       if (l.size == 0) {
         // if new cluster, add to set and position at centroid of leaf nodes
         nm[i] = nodes.length;
@@ -108,16 +112,24 @@ function network(data, prev, index, expand) {
           l.y = gc[i].y / gc[i].count;
         }
       }
-      l.size += 1;
       l.nodes.push(n);
     }
+	// always count group size as we also use it to tweak the force graph strengths/distances
+    l.size += 1;
+	n.group_data = l;
   }
+  
+  for (i in gm) { gm[i].link_count = 0; }
 
   // determine links
   for (k=0; k<data.links.length; ++k) {
     var e = data.links[k],
         u = index(e.source),
         v = index(e.target);
+	if (u != v) {
+	  gm[u].link_count++;
+	  gm[v].link_count++;
+	}
     u = expand[u] ? nm[e.source.name] : nm[u];
     v = expand[v] ? nm[e.target.name] : nm[v];
     var i = (u<v ? u+"|"+v : v+"|"+u),
@@ -145,12 +157,12 @@ function convexHulls(nodes, index, offset) {
   }
 
   // create convex hulls
-  var hulls = [];
+  var hullset = [];
   for (i in hulls) {
-    hulls.push({group: i, path: d3.geom.hull(hulls[i])});
+    hullset.push({group: i, path: d3.geom.hull(hulls[i])});
   }
 
-  return hulls;
+  return hullset;
 }
 
 function drawCluster(d) {
@@ -194,7 +206,32 @@ function init() {
       .nodes(net.nodes)
       .links(net.links)
       .size([width, height])
-      .linkDistance(50)
+      .linkDistance(function(l, i) {
+	    var n1 = l.source, n2 = l.target;
+		// larger distance for bigger groups:
+		// both between single nodes and _other_ groups (where size of own node group still counts),
+		// and between two group nodes.
+		// 
+		// reduce distance for groups with very few outer links,
+		// again both in expanded and grouped form, i.e. between individual nodes of a group and
+		// nodes of another group or other group node or between two group nodes.
+		//
+		// The latter was done to keep the single-link groups ('blue', rose, ...) close.
+		return 30 + 
+		  Math.min(20 * Math.min((n1.size || (n1.group != n2.group ? n1.group_data.size : 0)), 
+		                         (n2.size || (n1.group != n2.group ? n2.group_data.size : 0))), 
+				   -30 + 
+				   30 * Math.min((n1.link_count || (n1.group != n2.group ? n1.group_data.link_count : 0)),
+				                 (n2.link_count || (n1.group != n2.group ? n2.group_data.link_count : 0))), 
+				   100);
+	    //return 150;
+	  })
+	  .linkStrength(function(l, i) {
+		return 1;
+	  })
+	  .gravity(0.05)   // gravity+charge tweaked to ensure good 'grouped' view (e.g. green group not smack between blue&orange, ...
+	  .charge(-600)    // ... charge is important to turn single-linked groups to the outside
+	  .friction(0.5)   // friction adjusted to get dampened display: less bouncy bouncy ball [Swedish Chef, anyone?]
       .start();
 
   hullg.selectAll("path.hull").remove();
@@ -204,7 +241,9 @@ function init() {
       .attr("class", "hull")
       .attr("d", drawCluster)
       .style("fill", function(d) { return fill(d.group); })
-      .on("dblclick", function(d) { expand[d.group] = false; init(); });
+      .on("click", function(d) { 
+	    expand[d.group] = false; init(); 
+	  });
 
   link = linkg.selectAll("line.link").data(net.links, linkid);
   link.exit().remove();
@@ -219,13 +258,15 @@ function init() {
   node = nodeg.selectAll("circle.node").data(net.nodes, nodeid);
   node.exit().remove();
   node.enter().append("circle")
+      // if (d.size) -- d.size > 0 when d is a group node.
       .attr("class", function(d) { return "node" + (d.size?"":" leaf"); })
       .attr("r", function(d) { return d.size ? d.size + dr : dr+1; })
       .attr("cx", function(d) { return d.x; })
       .attr("cy", function(d) { return d.y; })
       .style("fill", function(d) { return fill(d.group); })
-      .on("dblclick", function(d) {
-        if (d.size) { expand[d.group] = true; init(); }
+      .on("click", function(d) {
+        expand[d.group] = !expand[d.group]; 
+		init(); 
       });
 
   node.call(force.drag);


### PR DESCRIPTION
...augmented example, showing distance function based on collected node/group info + click on node to expand/collapse (toggle) instead of harder-to-perform dblclick.

(fix: the force example had two var hulls (one object, one array) in a single function. It works, but is not something you want others to copy.)

Now the force-cluster example shows a graphic identical to http://bl.ocks.org/3071239
