### PR TITLE
force layout: properly UNSET the .fixed bits: user may be using further ...

### DIFF
--- a/src/layout/force.js
+++ b/src/layout/force.js
@@ -303,7 +303,7 @@ function d3_layout_forceDragstart(d) {
 }
 
 function d3_layout_forceDragend(d) {
-  d.fixed &= 1; // unset bits 2 and 3
+  d.fixed &= ~6; // unset bits 2 and 3
 }
 
 function d3_layout_forceMouseover(d) {
@@ -311,7 +311,7 @@ function d3_layout_forceMouseover(d) {
 }
 
 function d3_layout_forceMouseout(d) {
-  d.fixed &= 3; // unset bit 3
+  d.fixed &= ~4; // unset bit 3
 }
 
 function d3_layout_forceAccumulate(quad, alpha, charges) {


### PR DESCRIPTION
...bits and those should be kept intact.

(I use the force layout in several places where it was/is extremely handy to use the higher bits for my own augmentations, which depend on the internal 'if (node.fixed) { dont_move_node }' force.layout logic. 

One such example is http://bl.ocks.org/3616279 which is a layout which adds 'pinning' baheviour where nodes stick to the dragged-to location when you keep SHIFT or CTRL pressed when stopping the drag (when you try that gist, it has the known issue that it doesn't properly keep/release the pinned state; that's an irrelevant detail of that specific example.)
