### PR TITLE
export force.drag instance so user can access it by calling force.drag()...

### DIFF
--- a/src/layout/force.js
+++ b/src/layout/force.js
@@ -272,11 +272,13 @@ d3.layout.force = function() {
 
   // use `node.call(force.drag)` to make nodes draggable
   force.drag = function() {
+    if (!arguments.length) return drag;
+
     if (!drag) drag = d3.behavior.drag()
         .origin(d3_identity)
-        .on("dragstart", d3_layout_forceDragstart)
-        .on("drag", dragmove)
-        .on("dragend", d3_layout_forceDragend);
+        .on("dragstart.force", d3_layout_forceDragstart)
+        .on("drag.force", dragmove)
+        .on("dragend.force", d3_layout_forceDragend);
 
     this.on("mouseover.force", d3_layout_forceMouseover)
         .on("mouseout.force", d3_layout_forceMouseout)


### PR DESCRIPTION
... with no arguments; the drag events have been namespaced as <event>.force, similar to the other force events: mouseover.force and mouseout.force.

It is very useful for the user to be able to get access to the force layout's drag instance, so we can override/augment the drag behaviour easily (using namespaced events, f.e.); again http://bl.ocks.org/3616279 is one case where such ability is used to add a kind of 'pinning' behaviour for dragged nodes when SHIFT/CTRL has been pressed on mouse release.

The way this 'drag' instance reference is obtained is in line with other D3 functions, where calling it with no arguments returns the drag instance. (The documented use of drag via selection.call() happens to always call it with arguments, so that pans out nicely here :-) )
