### PR TITLE
Update chord.js to support negative matrix values

### DIFF
--- a/src/layout/chord.js
+++ b/src/layout/chord.js
@@ -26,7 +26,7 @@ d3.layout.chord = function() {
     // Compute the sum.
     k = 0, i = -1; while (++i < n) {
       x = 0, j = -1; while (++j < n) {
-        x += matrix[i][j];
+        x += Math.abs(matrix[i][j]);
       }
       groupSums.push(x);
       subgroupIndex.push(d3.range(n));
@@ -62,7 +62,7 @@ d3.layout.chord = function() {
             dj = subgroupIndex[di][j],
             v = matrix[di][dj],
             a0 = x,
-            a1 = x += v * k;
+            a1 = x += Math.abs(v) * k;
         subgroups[di + "-" + dj] = {
           index: di,
           subindex: dj,


### PR DESCRIPTION
The chord layout currently does not support negative values in input matrices; this commit provides support for negative values by making the chord group's angle dependent on the sum of the absolute value of all matrix input values in a group.