### PR TITLE
dsv.parse asynchronous when no arguments

### DIFF
--- a/src/dsv/dsv.js
+++ b/src/dsv/dsv.js
@@ -13,17 +13,22 @@ function d3_dsv(delimiter, mimeType) {
 
   dsv.parse = function(text) {
     var header;
-    return dsv.parseRows(text, function(row, i) {
-      if (i) {
-        var o = {}, j = -1, m = header.length;
-        while (++j < m) o[header[j]] = row[j];
-        return o;
-      } else {
-        header = row;
-        return null;
-      }
-    });
-  };
+
+    function process(text) {
+      return dsv.parseRows(text, function(row, i) {
+        if (header) {
+          var o = {}, j = -1, m = header.length;
+          while (++j < m) o[header[j]] = row[j];
+          return o;
+        } else {
+          header = row;
+          return null;
+        }
+      });
+    }
+
+    return (arguments.length) ? process(text) : process;
+  }
 
   dsv.parseRows = function(text, f) {
     var EOL = {}, // sentinel value for end-of-line


### PR DESCRIPTION
DSV data is special in the sense that it can be parsed incrementally (unlike json, xml etc).     This pull request allows an asynchronous version of dsv.parse when no arguments are passed to the constructor.  Should be backwards compatible.

Here is a quick hacked-up of an asynchronous csv function where .on("data"...) could for example add records to a Crossfilter, reducing the total time of loading and preparing the filter.

```
csvAsync = function(url) {
    var xhr = d3.xhr(url,"text/csv"),
        buffer = "",
        lastLocation = 0,
        parser = d3.csv.parse(),
        dataDispatch = d3.dispatch(["data"])
        on = xhr.on;

    xhr.on = function(source,args) {
        return (source=="data") ? dataDispatch.data.on.apply(xhr,arguments) : on.apply(xhr,arguments);
    }

    xhr.on("progress",function(d) {
        buffer += d3.event.target.responseText.slice(lastLocation);
        lastLocation = d3.event.loaded;
        var lines = buffer.split("\n");
        if (lines.length > 1) {
            var results = parser(lines.slice(0,lines.length-1).join("\n"));
            if (results.length) dataDispatch.data(results);
            buffer = results[results.length-1]
        }
    })
    return xhr.send("GET")
}
```

It might make sense to add a data dispatch to the d3.xhr object, for any partial data parsed so far (where applicable).  on("data"..) could return partial records (or full, if not supported)  and .on("load"..) the full dataset when done.
