### PR TITLE
Allow function as argument for append

### DIFF
--- a/src/core/selection-append.js
+++ b/src/core/selection-append.js
@@ -1,15 +1,11 @@
-// TODO append(node)?
-// TODO append(function)?
 d3_selectionPrototype.append = function(name) {
-  name = d3.ns.qualify(name);
-
+  var n = typeof name === "function" ? name.apply(this,arguments) : name;
   function append() {
-    return this.appendChild(document.createElementNS(this.namespaceURI, name));
+    return this.appendChild(document.createElementNS(this.namespaceURI, n));
   }
-
   function appendNS() {
-    return this.appendChild(document.createElementNS(name.space, name.local));
+    return this.appendChild(document.createElementNS(n.space, n.local));
   }
-
-  return this.select(name.local ? appendNS : append);
+  n = d3.ns.qualify(n);
+  return this.select(n.local ? appendNS : append)
 };


### PR DESCRIPTION
I was running into a problem where I needed to decide which type of element to append to the canvas based on data type and the obvious answer was to use an anonymous function. It looks like this was already being planned given the todos in code and in the [api documentation](https://github.com/mbostock/d3/wiki/Selections#wiki-append).
