### PR TITLE
Fix locale generation on Linux.

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -3,7 +3,7 @@ var fs = require("fs"),
     formats = {},
     kvRe = /=/,
     valueRe = /;/g,
-    quotedRe = /"([^"]+?)"/g,
+    quotedRe = /"([^"]*?)"/g,
     data = [];
 
 process.stdin.resume();


### PR DESCRIPTION
The regexp was not unquoting the empty string surrounded by quotes.

Fixes #976.
