### PR TITLE
Added check for headless run (tests)

### DIFF
--- a/src/core/mouse.js
+++ b/src/core/mouse.js
@@ -3,7 +3,10 @@ d3.mouse = function(container) {
 };
 
 // https://bugs.webkit.org/show_bug.cgi?id=44083
-var d3_mouse_bug44083 = /WebKit/.test(navigator.userAgent) ? -1 : 0;
+if(navigator === undefined)
+  var d3_mouse_bug44083 = 0;
+else
+  var d3_mouse_bug44083 = /WebKit/.test(navigator.userAgent) ? -1 : 0;
 
 function d3_mousePoint(container, e) {
   var svg = container.ownerSVGElement || container;


### PR DESCRIPTION
Tests were failing (not even starting) for me without this change. I'm still spotting many failures but maybe it is a problem due to my environment (node 0.8.15). An alternative would be to use a navigator emulator like https://github.com/coolaj86/node-navigator
