### PR TITLE
README.md: Point hyperlinks at github explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 **D3.js** is a JavaScript library for manipulating documents based on data. **D3** helps you bring data to life using HTML, SVG and CSS. D3’s emphasis on web standards gives you the full capabilities of modern browsers without tying yourself to a proprietary framework, combining powerful visualization components and a data-driven approach to DOM manipulation.
 
-Want to learn more? [See the wiki.](/mbostock/d3/wiki)
+Want to learn more? [See the wiki.](https://github.com/mbostock/d3/wiki)
 
-For examples, [see the gallery](/mbostock/d3/wiki/Gallery) and [mbostock’s bl.ocks](http://bl.ocks.org/mbostock).
+For examples, [see the gallery](https://github.com/mbostock/d3/wiki/Gallery) and [mbostock’s bl.ocks](http://bl.ocks.org/mbostock).


### PR DESCRIPTION
Using relative hyperlinks here results in some weirdness when the
readme is displayed on npmjs.org.

If this patch lands, I'd suggest also doing `npm publish -f` (or
just bump the version in package.json and `npm publish` un-forcefully.)
