### PR TITLE
Use (nw|ne|se|sw)-resize for intercardinal brush cursors

### DIFF
--- a/src/svg/brush.js
+++ b/src/svg/brush.js
@@ -344,10 +344,10 @@ var d3_svg_brushCursor = {
   e: "ew-resize",
   s: "ns-resize",
   w: "ew-resize",
-  nw: "nwse-resize",
-  ne: "nesw-resize",
-  se: "nwse-resize",
-  sw: "nesw-resize"
+  nw: "nw-resize",
+  ne: "ne-resize",
+  se: "se-resize",
+  sw: "sw-resize"
 };
 
 var d3_svg_brushResizes = [


### PR DESCRIPTION
`nwse-resize`, `nesw-resize`, `nwse-resize`, and `nesw-resize` don't display a custom cursor in Ubuntu Chromium 22, but works in Firefox. 

Cursor Test: http://jsfiddle.net/chriscoyier/wZ8K2/2/light/