### PR TITLE
jsdom globals deleted when loading as node module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var globals = ["document", "window", "navigator", "CSSStyleDeclaration", "getComputedStyle"],
+var globals = ["document", "window", "navigator", "CSSStyleDeclaration", "getComputedStyle", "d3"],
     globalValues = {};
 
 globals.forEach(function(g) {


### PR DESCRIPTION
This was failing:

`var d3 = require('d3');
d3.select("body").append("div"); //append fails because window.document is undefined`

The loops in index.js are trying to prevent global conflicts and/or keep multiple calls to require('d3') from being destructive? If so it should be safe to just delete the `delete global[g]` line?
