### PR TITLE
Increase biasing for Firefox's mousewheel events.

### DIFF
--- a/src/behavior/zoom.js
+++ b/src/behavior/zoom.js
@@ -201,7 +201,7 @@ function d3_behavior_zoomDelta() {
     d3_behavior_zoomDiv.dispatchEvent(e);
     delta = 1000 - d3_behavior_zoomDiv.scrollTop;
   } catch (error) {
-    delta = e.wheelDelta || (-e.detail * 5);
+    delta = e.wheelDelta || (-e.detail * 120);
   }
 
   return delta;


### PR DESCRIPTION
Based on testing (Mac, MBP, mouse wheel), Firefox consistently never
reports higher than -1 for 'single scroll events'.

Chart: https://gist.github.com/4692169

Other things of concern:
- The system of re-dispatching mousewheel events to a hidden div does
  not appear to be active on Safari/Chrome/Firefox - fails with a DOM
  Exception in all on my machine.
