### PR TITLE
Inject global d3 var

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -1,4 +1,4 @@
-(function() {
+var d3 = (function(d3) {
   var d3_format_decimalPoint = ".", d3_format_thousandsSeparator = ",", d3_format_grouping = [ 3, 3 ];
   if (!Date.now) Date.now = function() {
     return +new Date();
@@ -10,10 +10,7 @@
     d3_style_prototype.setProperty = function(name, value, priority) {
       d3_style_setProperty.call(this, name, value + "", priority);
     };
-  }
-  d3 = {
-    version: "3.0.5"
-  };
+  }  
   var π = Math.PI, ε = 1e-6, d3_radians = π / 180, d3_degrees = 180 / π;
   function d3_target(d) {
     return d.target;
@@ -7803,4 +7800,5 @@
   d3.time.scale.utc = function() {
     return d3_time_scale(d3.scale.linear(), d3_time_scaleUTCMethods, d3_time_scaleUTCFormat);
   };
-})();
+  return d3;
+})({version: "3.0.5"});


### PR DESCRIPTION
It is nice if one can move the global variable for a library to another namespace and then delete the global. For instance, with jQuery I can move $ to MyAppNamespace.$, then delete window.$. jQuery will continue to work after this.

d3 does not continue to work if I attempt the same thing. This is because the d3 global variable is declared within the main function body as a global, and is not injected. With the simple changes here I am free to reassign the global d3 variable into my own namespace.
