### PR TITLE
Rebind returns target when the source returns itself

### DIFF
--- a/src/core/rebind.js
+++ b/src/core/rebind.js
@@ -11,6 +11,6 @@ d3.rebind = function(target, source) {
 function d3_rebind(target, source, method) {
   return function() {
     var value = method.apply(source, arguments);
-    return arguments.length || value === source ? target : value;
+    return value === source ? target : value;
   };
 }


### PR DESCRIPTION
The logic is as follows:  If a rebound function returns the source object, we should return the target object, even when no arguments were supplied.

Example:   If I rebind a dispatch object to a target object and call a dispatch function with no argument, it will return the target, not the dispatch object, allowing for proper chaining.
