### PR TITLE
Allow insert before dom element

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -1659,11 +1659,17 @@ d3 = function() {
   };
   d3_selectionPrototype.insert = function(name, before) {
     name = d3.ns.qualify(name);
+    var referenceElement;
+    if(typeof before === "object"){
+      referenceElement = before;
+    }else{
+      referenceElement = d3_select(before, this);
+    }
     function insert() {
-      return this.insertBefore(d3_document.createElementNS(this.namespaceURI, name), d3_select(before, this));
+      return this.insertBefore(document.createElementNS(this.namespaceURI, name), referenceElement);
     }
     function insertNS() {
-      return this.insertBefore(d3_document.createElementNS(name.space, name.local), d3_select(before, this));
+      return this.insertBefore(document.createElementNS(name.space, name.local), referenceElement);
     }
     return this.select(name.local ? insertNS : insert);
   };


### PR DESCRIPTION
'before' argument can now either be a query selector or a dom element.
This is handy if you have the dom element to hand and woud find it
awkward to derive a query selector from it.
