### PR TITLE
add colorbrewer global name

### DIFF
--- a/lib/colorbrewer/colorbrewer.js
+++ b/lib/colorbrewer/colorbrewer.js
@@ -1,5 +1,5 @@
 // This product includes color specifications and designs developed by Cynthia Brewer (http://colorbrewer.org/).
-{YlGn: {
+var colorbrewer = {YlGn: {
 3: ["#f7fcb9","#addd8e","#31a354"],
 4: ["#ffffcc","#c2e699","#78c679","#238443"],
 5: ["#ffffcc","#c2e699","#78c679","#31a354","#006837"],


### PR DESCRIPTION
looks like you deleted `var colorbrewer =` when you reformatted it.
