### PR TITLE
d3.dsv support for files without headers

### DIFF
--- a/src/dsv/dsv.js
+++ b/src/dsv/dsv.js
@@ -2,19 +2,18 @@ function d3_dsv(delimiter, mimeType) {
   var reFormat = new RegExp("[\"" + delimiter + "\n]"),
       delimiterCode = delimiter.charCodeAt(0);
 
-  function dsv(url, callback) {
-    return d3.xhr(url, mimeType, callback).response(response);
+  function dsv(url, callback, make) {
+    return d3.xhr(url, mimeType, callback).response(function(req) { return response(req, make); });
   }
 
-  function response(request) {
-    return dsv.parse(request.responseText);
+  function response(request, make) {
+    return dsv.parse(request.responseText, make);
   }
 
-  dsv.parse = function(text) {
-    var o;
+  dsv.parse = function(text, make) {
     return dsv.parseRows(text, function(row) {
-      if (o) return o(row);
-      o = new Function("d", "return {" + row.map(function(name, i) {
+      if (make) return make(row);
+      make = new Function("d", "return {" + row.map(function(name, i) {
         return JSON.stringify(name) + ": d[" + i + "]";
       }).join(",") + "}");
     });


### PR DESCRIPTION
The following patch is a minimal addition to d3.dsv to bypass the creation of the construction function, in case the file doesn't contain headers. In that case, the user is responsible for passing a construction function:

```
d3.csv("foo", callback, function(a) { return { "field1": a[0], "field2": a[1]} });
```

This might be marginally useful as well for cases where users don't want the entire dsv.

Not sure if this different API is in acceptable style, but the feature has been useful for me on occasion.
