### PR TITLE
adding step-middle as interpolation method

### DIFF
--- a/src/svg/line.js
+++ b/src/svg/line.js
@@ -130,10 +130,10 @@ function d3_svg_lineStepBefore(points) {
 
 // Step interpolation; generates "H" and "V" commands.
 function d3_svg_lineStep(points) {
-  var i = 0, n = points.length, p = points[0], path = [ p[0], ",", p[1] ];
+  var i = 0, n = points.length, p0, p1 = points[0], path = [ p1[0], ",", p1[1] ];
   while (++i < n) {
-    var prev = points[i-1], p = points[i];
-    path.push("H", (p[0] - prev[0])/2 + prev[0], "V", p[1], "H", p[0]);
+    p0 = p1, p1 = points[i];
+    path.push("H", (p0[0] + p1[0]) / 2, "V", p1[1], "H", p1[0]);
   }
   return path.join("");
 }

--- a/test/svg/line-test.js
+++ b/test/svg/line-test.js
@@ -93,7 +93,7 @@ suite.addBatch({
         assert.pathEqual(l([[0, 0], [1, 1]]), "M0,0V1H1");
         assert.pathEqual(l([[0, 0], [1, 1], [2, 0]]), "M0,0V1H1V0H2");
       },
-      "supports step-middle interpolation": function(line) {
+      "supports step interpolation": function(line) {
         var l = line().interpolate("step");
         assert.pathEqual(l([[0, 0]]), "M0,0");
         assert.pathEqual(l([[0, 0], [1, 1]]), "M0,0H0.5V1H1");


### PR DESCRIPTION
I recently needed to use this functionality in a graph.  It does what it sounds like it should do, i.e. steps between two points on a line instead of before or after.

A test has also been added for the functionality.
