### PR TITLE
Updated package.json to include d3's license

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,11 @@
   },
   "scripts": {
     "test": "node_modules/.bin/vows; echo"
-  }
+  },
+  "licenses": [
+    {
+      "type": "BSD",
+      "url": "https://github.com/mbostock/d3/blob/master/LICENSE"
+    }
+  ]
 }


### PR DESCRIPTION
NPM spec allows for d3's license in the package.json, so for completeness, I added it in :)

https://npmjs.org/doc/json.html
