### PR TITLE
Fix for #1005 - fix click suppression after dragend in cases where click doesn't fire.

### DIFF
--- a/src/behavior/drag.js
+++ b/src/behavior/drag.js
@@ -65,17 +65,11 @@ d3.behavior.drag = function() {
       // if moved, prevent the mouseup (and possibly click) from propagating
       if (moved) {
         d3_eventCancel();
-        if (d3.event.target === eventTarget) w.on("click.drag", click, true);
+        if (d3.event.target === eventTarget) d3_eventSuppress('click');
       }
 
       w .on(touchId != null ? "touchmove.drag-" + touchId : "mousemove.drag", null)
         .on(touchId != null ? "touchend.drag-" + touchId : "mouseup.drag", null);
-    }
-
-    // prevent the subsequent click from propagating (e.g., for anchors)
-    function click() {
-      d3_eventCancel();
-      w.on("click.drag", null);
     }
   }
 

--- a/src/behavior/zoom.js
+++ b/src/behavior/zoom.js
@@ -115,12 +115,7 @@ d3.behavior.zoom = function() {
     function mouseup() {
       if (moved) d3_eventCancel();
       w.on("mousemove.zoom", null).on("mouseup.zoom", null);
-      if (moved && d3.event.target === eventTarget) w.on("click.zoom", click, true);
-    }
-
-    function click() {
-      d3_eventCancel();
-      w.on("click.zoom", null);
+      if (moved && d3.event.target === eventTarget) d3_eventSuppress('click');
     }
   }
 

--- a/src/event/event.js
+++ b/src/event/event.js
@@ -13,6 +13,22 @@ function d3_eventSource() {
   return e;
 }
 
+// In some cases, e.g. on dragend of behavior.zoom and behavior.drag, we need
+// to suppress an event that fires immediately.
+function d3_eventSuppress(name) {
+  var w = d3.select(d3_window);
+  function unbind() {
+    w.on(name + ".suppress", null);
+  }
+  w.on(name + ".suppress", function() {
+    // prevent the subsequent event from propagating (e.g., for anchors)
+    d3_eventCancel();
+    unbind();
+  }, true);
+  // clear the handler after a 0ms timeout in case it doesn't fire after all
+  setTimeout(unbind, 0);
+}
+
 // Like d3.dispatch, but for custom events abstracting native UI events. These
 // events have a target component (such as a brush), a target element (such as
 // the svg:g element containing the brush) and the standard arguments `d` (the


### PR DESCRIPTION
Fixes Issue #1005 for both behavior.zoom and behavior.drag

This fixes (which we're using at appneta to fix this issue in our app for both zoom and drag) cases when code intended to suppress superfluous click events on dragend causes a later click (anywhere on the page) to be absorbed.

Since the undesired click event should fire immediately after dragend, before returning to the JS event loop, the 0ms setTimeout where we clear the handler would only ever fire after the click event.  This should also take place fast enough that most human users would never make a subsequent click before the setTimeout fires.

This is a bit hacky as noted in https://github.com/mbostock/d3/issues/1005#issuecomment-15592805, but is probably less complicated than trying to discern cases/browsers/versions where the click does and does not fire.
