### PR TITLE
fix component support

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,5 +1,6 @@
 {
   "name": "d3",
   "version": "3.1.4",
-  "main": "./d3.js"
+  "main": "index-browserify.js",
+  "scripts": ["index-browserify.js", "d3.js"]
 }

--- a/index-browserify.js
+++ b/index-browserify.js
@@ -1,2 +1,5 @@
 require("./d3");
 module.exports = d3;
+
+// unset global variable
+(function () { delete this.d3; })();


### PR DESCRIPTION
I'd like to use d3 as a [component](https://github.com/component/component). @visionmedia has created [component/d3](https://github.com/component/d3), but it is out of date, and generally keeping it up to date is non-sustainable since it involves human intervention. So let's make this repo a component.

I noticed there is a [component.json](https://github.com/mbostock/d3/blob/master/component.json) file in the repo, but it wont work since a couple things are missing. Particularly:
- `main` needs to be in `scripts` also. (see [spec](https://github.com/component/component/wiki/Spec#main))
- `d3` needs to be exported in [d3.js](https://github.com/mbostock/d3/blob/master/d3.js) so that it can be `require()`ed later.

This PR fixes the issues mentioned above, but it might be missing a few things.
- I'm not sure about the [globals.js](https://github.com/mbostock/d3/blob/master/globals.js)
- the `module.exports` added detection at the bottom of [d3.js](https://github.com/danmilon/d3/blob/bc9932af96fbe8d88655849705cd5e40588c2e59/d3.js#L8440-L8442) might not be desired

Suggestions are welcome.
