### PR TITLE
Optimize tick function in Force layout

### DIFF
--- a/src/layout/force.js
+++ b/src/layout/force.js
@@ -70,6 +70,13 @@ d3.layout.force = function() {
         x, // x-distance
         y; // y-distance
 
+    //For default alpha of 0.1, tick is iterated 298 times
+    //If the number of nodes is zero or becomes zero, no need to continue ticking
+    if (n==0) {
+      event.end({type: "end", alpha: alpha = 0});
+      return true;
+    }
+
     // gauss-seidel relaxation for links
     for (i = 0; i < m; ++i) {
       o = links[i];


### PR DESCRIPTION
For the default value of alpha (0.1), the tick function is executed 298 times.

If there are no nodes (unlikely; nobody is going to start the force layout without nodes) or all nodes removed in the course of animation (possible), there is no need to continue ticking anymore.

Added a check near the top of tick function to end ticking if the number of nodes is/becomes zero.
