### PR TITLE
Improved Windows support for 'npm test'

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vows": "0.7.x"
   },
   "scripts": {
-    "test": "node_modules/.bin/vows"
+    "test": "vows"
   },
   "licenses": [
     {


### PR DESCRIPTION
The provided test script `node_modules/.bin/vows`, works well in Unix shells, but in Command Prompt and Cygwin, it generates an error `'node_modules' is not recognized as an internal or external command`. I was able to run `npm test` in Windows by shortening the script to just `vows`.
