### PR TITLE
Windows support for 'npm test' while referencing local vows version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vows": "0.7.x"
   },
   "scripts": {
-    "test": "node_modules/.bin/vows"
+    "test": "node node_modules/vows/bin/vows"
   },
   "licenses": [
     {


### PR DESCRIPTION
As suggested in https://github.com/mbostock/d3/pull/1225#issuecomment-17362699.
