### PR TITLE
Tweak version generation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,26 +15,27 @@ test:
 benchmark: all
 	@node test/geo/benchmark.js
 
-src/format/format-localized.js: src/locale.js src/format/format-locale.js
-	LC_NUMERIC=$(LOCALE) locale -ck LC_NUMERIC | node src/locale.js src/format/format-locale.js > $@
+src/format/format-localized.js: bin/locale src/format/format-locale.js
+	LC_NUMERIC=$(LOCALE) locale -ck LC_NUMERIC | bin/locale src/format/format-locale.js > $@
 
-src/time/format-localized.js: src/locale.js src/time/format-locale.js
-	LC_TIME=$(LOCALE) locale -ck LC_TIME | node src/locale.js src/time/format-locale.js > $@
+src/time/format-localized.js: bin/locale src/time/format-locale.js
+	LC_TIME=$(LOCALE) locale -ck LC_TIME | bin/locale src/time/format-locale.js > $@
+
+src/start.js: package.json bin/start
+	bin/start > $@
 
 d3.js: $(shell node_modules/.bin/smash --list src/d3.js) package.json
 	@rm -f $@
-	node_modules/.bin/smash src/d3.js \
-		| sed 's/[[:<:]]VERSION[[:>:]]/"$(shell ./version)"/' \
-		| node_modules/.bin/uglifyjs - -b indent-level=2 -o $@
+	node_modules/.bin/smash src/d3.js | node_modules/.bin/uglifyjs - -b indent-level=2 -o $@
 	@chmod a-w $@
 
 d3.min.js: d3.js
 	@rm -f $@
 	node_modules/.bin/uglifyjs $< -c -m -o $@
 
-component.json: src/component.js d3.js package.json
+component.json: bin/component d3.js package.json
 	@rm -f $@
-	node src/component.js > $@
+	bin/component > $@
 	@chmod a-w $@
 
 clean:

--- a/bin/component
+++ b/bin/component
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 console.log(JSON.stringify({
   "name": "d3",
   "version": require("../package.json").version,

--- a/bin/locale
+++ b/bin/locale
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var fs = require("fs"),
     puts = require("util").puts,
     formats = {},

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("d3 = (function(){\n  var d3 = {version: " + JSON.stringify(require("../package.json").version) + "}; // semver");

--- a/src/start.js
+++ b/src/start.js
@@ -1,2 +1,2 @@
 d3 = (function(){
-  var d3 = {version: VERSION}; // semver
+  var d3 = {version: "3.1.6"}; // semver

--- a/version
+++ b/version
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-console.log(require("./package.json").version);


### PR DESCRIPTION
Instead of relying on sed to replace a VERSION token, we generate `src/start.js`, which defines the internal `d3` variable with the current version derived from package.json.
