### PR TITLE
Fix time tests by adding Date to sandbox.

### DIFF
--- a/test/load.js
+++ b/test/load.js
@@ -8,7 +8,7 @@ require("./XMLHttpRequest");
 module.exports = function() {
   var files = [].slice.call(arguments).map(function(d) { return "src/" + d; }),
       expression = "d3",
-      sandbox = null;
+      sandbox = {Date: Date}; // so we can use deepEqual in tests
 
   files.unshift("src/start");
   files.push("src/end");
@@ -40,7 +40,7 @@ module.exports = function() {
       window: document.createWindow(),
       setTimeout: setTimeout,
       clearTimeout: clearTimeout,
-      Date: Date // so we can override Date.now in tests
+      Date: Date // so we can override Date.now in tests, and use deepEqual
     };
 
     return topic;


### PR DESCRIPTION
Since tests are now run in their own sandbox, assert.deepEqual was not properly testing the returned Date objects for equality, as they weren't instances of the same Date class used by the test itself, causing type inference to fail.

It was always returning true, even for different dates!

An alternative fix would be to define our own assert.dateEqual, which would compare .getTime() directly instead of using type inference.
