### PR TITLE
require('d3') on serverside does not initialize global object's window or document properties.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,4 @@ var globals = ["document", "window", "d3"],
 require("./globals");
 require("./d3");
 
-globals.forEach(function(g) {
-  if (g in global) globalValues[g] = global[g];
-});
-
 module.exports = d3;
-
-globals.forEach(function(g) {
-  if (g in globalValues) global[g] = globalValues[g];
-  else delete global[g];
-});


### PR DESCRIPTION
`global` object does not have reference to `window` and `document` before `require('/globals')` so the forEach statements are pointless and harmful because global does not yet have a pointer to window and document Removing them would fix the issue that global object does not have window and document properties.
