### PR TITLE
restoring original children in d3.layout.hierarchy

### DIFF
--- a/d3.js
+++ b/d3.js
@@ -5403,7 +5403,7 @@ d3 = function() {
       node.depth = depth;
       nodes.push(node);
       if (childs && (n = childs.length)) {
-        var holdChildren = node.children;
+        var holdChildren = childs;
         var i = -1, n, c = node.children = [], v = 0, j = depth + 1, d;
         while (++i < n) {
           d = recurse(childs[i], j, nodes);


### PR DESCRIPTION
changed hierarchy recurse function to put back original (changed) children so methods on that array won't get clobbered
