### PR TITLE
Allow call() on selections following enter()

### DIFF
--- a/src/selection/enter.js
+++ b/src/selection/enter.js
@@ -15,5 +15,6 @@ d3_selection_enterPrototype.append = d3_selectionPrototype.append;
 d3_selection_enterPrototype.insert = d3_selectionPrototype.insert;
 d3_selection_enterPrototype.empty = d3_selectionPrototype.empty;
 d3_selection_enterPrototype.node = d3_selectionPrototype.node;
+d3_selection_enterPrototype.call = d3_selectionPrototype.call;
 
 import "enter-select";


### PR DESCRIPTION
The following fails with error "Uncaught TypeError: Object [object Array] has no method 'call'".  I'm using Chrome 26. 

``` javascript
d3.select('body').data([0]).enter().call(function () { alert('called!'); });
```

I'm new to d3, so this fix may be dangerous in some way I don't understand.
