### PR TITLE
Include an API for SVG transform attributes

### DIFF
--- a/src/svg/index.js
+++ b/src/svg/index.js
@@ -10,3 +10,4 @@ import "diagonal-radial";
 import "symbol";
 import "axis";
 import "brush";
+import "transform";

--- a/src/svg/transform.js
+++ b/src/svg/transform.js
@@ -1,0 +1,37 @@
+(function() {
+  d3.svg.transform = function(chain) {
+    var transforms = [];
+    if (chain !== undefined) { transforms.push(chain) }
+
+    function push(kind, args) {
+      var n = args.length;
+
+      transforms.push(function() {
+        return kind + '(' + (n == 1 && typeof args[0] == 'function'
+            ? args[0].apply(this, arr(arguments)) : args) + ')';
+      });
+    };
+
+    function arr(args) {
+      return Array.prototype.slice.call(args);
+    }
+
+    var my = function() {
+      var that = this,
+          args = arr(arguments);
+
+      return transforms.map(function(f) {
+        return f.apply(that, args);
+      }).join(' ');
+    };
+
+    ['translate', 'rotate', 'scale', 'matrix', 'skewX', 'skewY'].forEach(function(t) {
+      my[t] = function() {
+        push(t, arr(arguments));
+        return my;
+      };
+    });
+
+    return my;
+  };
+})();

--- a/src/svg/transform.js
+++ b/src/svg/transform.js
@@ -1,37 +1,37 @@
-(function() {
-  d3.svg.transform = function(chain) {
-    var transforms = [];
-    if (chain !== undefined) { transforms.push(chain) }
+import "svg";
 
-    function push(kind, args) {
-      var n = args.length;
+d3.svg.transform = function(chain) {
+  var transforms = [];
+  if (chain !== undefined) { transforms.push(chain) }
 
-      transforms.push(function() {
-        return kind + '(' + (n == 1 && typeof args[0] == 'function'
-            ? args[0].apply(this, arr(arguments)) : args) + ')';
-      });
-    };
+  function push(kind, args) {
+    var n = args.length;
 
-    function arr(args) {
-      return Array.prototype.slice.call(args);
-    }
-
-    var my = function() {
-      var that = this,
-          args = arr(arguments);
-
-      return transforms.map(function(f) {
-        return f.apply(that, args);
-      }).join(' ');
-    };
-
-    ['translate', 'rotate', 'scale', 'matrix', 'skewX', 'skewY'].forEach(function(t) {
-      my[t] = function() {
-        push(t, arr(arguments));
-        return my;
-      };
+    transforms.push(function() {
+      return kind + '(' + (n == 1 && typeof args[0] == 'function'
+          ? args[0].apply(this, arr(arguments)) : args) + ')';
     });
-
-    return my;
   };
-})();
+
+  function arr(args) {
+    return Array.prototype.slice.call(args);
+  }
+
+  var my = function() {
+    var that = this,
+        args = arr(arguments);
+
+    return transforms.map(function(f) {
+      return f.apply(that, args);
+    }).join(' ');
+  };
+
+  ['translate', 'rotate', 'scale', 'matrix', 'skewX', 'skewY'].forEach(function(t) {
+    my[t] = function() {
+      push(t, arr(arguments));
+      return my;
+    };
+  });
+
+  return my;
+};

--- a/src/svg/transform.js
+++ b/src/svg/transform.js
@@ -1,3 +1,4 @@
+import "../core/array";
 import "svg";
 
 d3.svg.transform = function(chain) {
@@ -9,17 +10,13 @@ d3.svg.transform = function(chain) {
 
     transforms.push(function() {
       return kind + '(' + (n == 1 && typeof args[0] == 'function'
-          ? args[0].apply(this, arr(arguments)) : args) + ')';
+          ? args[0].apply(this, arguments) : args) + ')';
     });
   };
 
-  function arr(args) {
-    return Array.prototype.slice.call(args);
-  }
-
   var my = function() {
     var that = this,
-        args = arr(arguments);
+        args = arguments;
 
     return transforms.map(function(f) {
       return f.apply(that, args);
@@ -28,7 +25,7 @@ d3.svg.transform = function(chain) {
 
   ['translate', 'rotate', 'scale', 'matrix', 'skewX', 'skewY'].forEach(function(t) {
     my[t] = function() {
-      push(t, arr(arguments));
+      push(t, d3_array(arguments));
       return my;
     };
   });

--- a/test/svg/transform-test.js
+++ b/test/svg/transform-test.js
@@ -1,0 +1,82 @@
+var vows = require('vows'),
+    assert = require('assert');
+
+/*
+ * Don't require d3 in a var declaration so the name is available to
+ * d3-transform. This makes it global, which should probably be avoided but
+ * ???
+ */
+d3 = require('d3');
+var transform = require("../src/d3-transform.js");
+
+vows.describe('d3-transform').addBatch({
+  'the initial object' : {
+    topic : function() {
+      return d3.svg.transform();
+    },
+    'is an identity transform' : function(topic) {
+      assert.equal(topic(), "");
+    }
+  },
+  'calling translate' : {
+    'works for one argument' : function() {
+      var transform = d3.svg.transform()
+          .translate(1);
+
+      assert.equal(transform(), 'translate(1)');
+    },
+    'works for two arguments' : function() {
+      var transform = d3.svg.transform()
+          .translate(1, 2);
+
+      assert.equal(transform(), 'translate(1,2)');
+    },
+    'works for a function argument' : function() {
+      var transform = d3.svg.transform()
+          .translate(function() { return [3, 5]; });
+
+      assert.equal(transform(), 'translate(3,5)');
+    },
+    'works for a function argument, given arguments' : function() {
+      var transform = d3.svg.transform()
+          .translate(function(x) { return [x, 13]; });
+
+      assert.equal(transform(8), 'translate(8,13)');
+    },
+    'works for a function argument, as a method' : function() {
+      var transform = d3.svg.transform()
+          .translate(function() { return [this.x, 34]; });
+      var cxt = { 'x' : 21 };
+
+      assert.equal(transform.call(cxt), 'translate(21,34)');
+    }
+  },
+  'composing transforms' : {
+    'works' : function() {
+      var transform = d3.svg.transform()
+          .translate(1, 1)
+          .rotate(2);
+      assert.equal(transform(), 'translate(1,1) rotate(2)');
+    }
+  },
+  'composing multiple transform objects' : {
+    'works' : function() {
+      var t1 = d3.svg.transform()
+        .translate(1,1)
+        .rotate(2)
+      var t2 = d3.svg
+        .transform(t1)
+        .scale(3,3);
+      assert.equal(t2(),"translate(1,1) rotate(2) scale(3,3)");
+    },
+    'works with functions at any point' : function() {
+      var t1 = d3.svg.transform()
+        .translate(function(d) { return [d,1];})
+        .rotate(2)
+      var t2 = d3.svg
+        .transform(t1)
+        .scale(function(d) { return [d+1,4];});
+      assert.equal(t2(10),"translate(10,1) rotate(2) scale(11,4)");
+    }
+  }
+}).export(module);

--- a/test/svg/transform-test.js
+++ b/test/svg/transform-test.js
@@ -1,82 +1,77 @@
-var vows = require('vows'),
-    assert = require('assert');
+var vows = require("vows"),
+    load = require("../load"),
+    assert = require("../assert");
 
-/*
- * Don't require d3 in a var declaration so the name is available to
- * d3-transform. This makes it global, which should probably be avoided but
- * ???
- */
-d3 = require('d3');
-var transform = require("../src/d3-transform.js");
-
-vows.describe('d3-transform').addBatch({
-  'the initial object' : {
-    topic : function() {
-      return d3.svg.transform();
+var suite = vows.describe("d3.svg.transform");
+suite.addBatch({
+  "transform" : {
+    topic: load("svg/transform").expression("d3.svg.transform"),
+    'the initial object' : {
+      'is an identity transform' : function(transform) {
+        var t1 = transform();
+        assert.equal(t1(),"");
+      }
     },
-    'is an identity transform' : function(topic) {
-      assert.equal(topic(), "");
-    }
-  },
-  'calling translate' : {
-    'works for one argument' : function() {
-      var transform = d3.svg.transform()
-          .translate(1);
+    'calling translate' : {
+      topic: load("svg/transform").expression("d3.svg.transform"),
+      'works for one argument' : function(transform) {
+        var t1 = transform();
+        t1.translate(1);
 
-      assert.equal(transform(), 'translate(1)');
+        assert.equal(t1(), 'translate(1)');
+      },
+      'works for two arguments' : function(transform) {
+        var t1 = transform();
+        t1.translate(1, 2);
+        assert.equal(t1(), 'translate(1,2)');
+      },
+      'works for a function argument' : function(transform) {
+        var t1 = transform();
+        t1.translate(function() { return [3, 5]; });
+
+        assert.equal(t1(), 'translate(3,5)');
+      },
+      'works for a function argument, given arguments' : function(transform) {
+        var transform = transform()
+            .translate(function(x) { return [x, 13]; });
+
+        assert.equal(transform(8), 'translate(8,13)');
+      },
+      'works for a function argument, as a method' : function(transform) {
+        var transform = transform()
+            .translate(function() { return [this.x, 34]; });
+        var cxt = { 'x' : 21 };
+
+        assert.equal(transform.call(cxt), 'translate(21,34)');
+      }
     },
-    'works for two arguments' : function() {
-      var transform = d3.svg.transform()
-          .translate(1, 2);
-
-      assert.equal(transform(), 'translate(1,2)');
-    },
-    'works for a function argument' : function() {
-      var transform = d3.svg.transform()
-          .translate(function() { return [3, 5]; });
-
-      assert.equal(transform(), 'translate(3,5)');
-    },
-    'works for a function argument, given arguments' : function() {
-      var transform = d3.svg.transform()
-          .translate(function(x) { return [x, 13]; });
-
-      assert.equal(transform(8), 'translate(8,13)');
-    },
-    'works for a function argument, as a method' : function() {
-      var transform = d3.svg.transform()
-          .translate(function() { return [this.x, 34]; });
-      var cxt = { 'x' : 21 };
-
-      assert.equal(transform.call(cxt), 'translate(21,34)');
-    }
-  },
-  'composing transforms' : {
-    'works' : function() {
-      var transform = d3.svg.transform()
-          .translate(1, 1)
+    'composing transforms' : {
+      topic: load("svg/transform").expression("d3.svg.transform"),
+      'works' : function(transform) {
+        var t1 = transform();
+        t1.translate(1, 1)
           .rotate(2);
-      assert.equal(transform(), 'translate(1,1) rotate(2)');
-    }
-  },
-  'composing multiple transform objects' : {
-    'works' : function() {
-      var t1 = d3.svg.transform()
-        .translate(1,1)
-        .rotate(2)
-      var t2 = d3.svg
-        .transform(t1)
-        .scale(3,3);
-      assert.equal(t2(),"translate(1,1) rotate(2) scale(3,3)");
+        assert.equal(t1(), 'translate(1,1) rotate(2)');
+      }
     },
-    'works with functions at any point' : function() {
-      var t1 = d3.svg.transform()
-        .translate(function(d) { return [d,1];})
-        .rotate(2)
-      var t2 = d3.svg
-        .transform(t1)
-        .scale(function(d) { return [d+1,4];});
-      assert.equal(t2(10),"translate(10,1) rotate(2) scale(11,4)");
+    'composing multiple transform objects' : {
+      topic: load("svg/transform").expression("d3.svg.transform"),
+      'works' : function(transform) {
+        var t1 = transform()
+          .translate(1,1)
+          .rotate(2)
+        var t2 = transform(t1)
+          .scale(3,3);
+        assert.equal(t2(),"translate(1,1) rotate(2) scale(3,3)");
+      },
+      'works with functions at any point' : function(transform) {
+        var t1 = transform()
+          .translate(function(d) { return [d,1];})
+          .rotate(2)
+        var t2 = transform(t1)
+          .scale(function(d) { return [d+1,4];});
+        assert.equal(t2(10),"translate(10,1) rotate(2) scale(11,4)");
+      }
     }
   }
 }).export(module);

--- a/test/svg/transform-test.js
+++ b/test/svg/transform-test.js
@@ -5,40 +5,40 @@ var vows = require("vows"),
 var suite = vows.describe("d3.svg.transform");
 suite.addBatch({
   "transform" : {
-    topic: load("svg/transform").expression("d3.svg.transform"),
+    topic: load("svg/transform").document(),
     'the initial object' : {
-      'is an identity transform' : function(transform) {
-        var t1 = transform();
+      'is an identity transform' : function(d3) {
+        var t1 = d3.svg.transform();
         assert.equal(t1(),"");
       }
     },
     'calling translate' : {
-      topic: load("svg/transform").expression("d3.svg.transform"),
-      'works for one argument' : function(transform) {
-        var t1 = transform();
+      topic: load("svg/transform").document(),
+      'works for one argument' : function(d3) {
+        var t1 = d3.svg.transform();
         t1.translate(1);
 
         assert.equal(t1(), 'translate(1)');
       },
-      'works for two arguments' : function(transform) {
-        var t1 = transform();
+      'works for two arguments' : function(d3) {
+        var t1 = d3.svg.transform();
         t1.translate(1, 2);
         assert.equal(t1(), 'translate(1,2)');
       },
-      'works for a function argument' : function(transform) {
-        var t1 = transform();
+      'works for a function argument' : function(d3) {
+        var t1 = d3.svg.transform();
         t1.translate(function() { return [3, 5]; });
 
         assert.equal(t1(), 'translate(3,5)');
       },
-      'works for a function argument, given arguments' : function(transform) {
-        var transform = transform()
+      'works for a function argument, given arguments' : function(d3) {
+        var transform = d3.svg.transform()
             .translate(function(x) { return [x, 13]; });
 
         assert.equal(transform(8), 'translate(8,13)');
       },
-      'works for a function argument, as a method' : function(transform) {
-        var transform = transform()
+      'works for a function argument, as a method' : function(d3) {
+        var transform = d3.svg.transform()
             .translate(function() { return [this.x, 34]; });
         var cxt = { 'x' : 21 };
 
@@ -46,29 +46,29 @@ suite.addBatch({
       }
     },
     'composing transforms' : {
-      topic: load("svg/transform").expression("d3.svg.transform"),
-      'works' : function(transform) {
-        var t1 = transform();
+      topic: load("svg/transform").document(),
+      'works' : function(d3) {
+        var t1 = d3.svg.transform();
         t1.translate(1, 1)
           .rotate(2);
         assert.equal(t1(), 'translate(1,1) rotate(2)');
       }
     },
     'composing multiple transform objects' : {
-      topic: load("svg/transform").expression("d3.svg.transform"),
-      'works' : function(transform) {
-        var t1 = transform()
+      topic: load("svg/transform").document(),
+      'works' : function(d3) {
+        var t1 = d3.svg.transform()
           .translate(1,1)
           .rotate(2)
-        var t2 = transform(t1)
+        var t2 = d3.svg.transform(t1)
           .scale(3,3);
         assert.equal(t2(),"translate(1,1) rotate(2) scale(3,3)");
       },
-      'works with functions at any point' : function(transform) {
-        var t1 = transform()
+      'works with functions at any point' : function(d3) {
+        var t1 = d3.svg.transform()
           .translate(function(d) { return [d,1];})
           .rotate(2)
-        var t2 = transform(t1)
+        var t2 = d3.svg.transform(t1)
           .scale(function(d) { return [d+1,4];});
         assert.equal(t2(10),"translate(10,1) rotate(2) scale(11,4)");
       }


### PR DESCRIPTION
d3-transform makes it easy to define and reuse functions that produce transform attribute strings for SVG elements. Using d3-transform reduces repetition, allows you to compose multiple transforms, and eliminates ugly string-interpolation from transform attr calls.

More info and docs here: https://github.com/trinary/d3-transform#readme

This PR includes that transform API and adapts the code and tests in that repo to fit d3's existing structure and style.