### PR TITLE
d3.geo.circle: ensure coincident start/end points.

### DIFF
--- a/src/geo/circle.js
+++ b/src/geo/circle.js
@@ -52,16 +52,16 @@ function d3_geo_circleInterpolate(radius, precision) {
   var cr = Math.cos(radius),
       sr = Math.sin(radius);
   return function(from, to, direction, listener) {
+    var step = direction * precision;
     if (from != null) {
       from = d3_geo_circleAngle(cr, from);
       to = d3_geo_circleAngle(cr, to);
       if (direction > 0 ? from < to: from > to) from += direction * 2 * π;
     } else {
       from = radius + direction * 2 * π;
-      to = radius;
+      to = radius - .5 * step;
     }
-    var point;
-    for (var step = direction * precision, t = from; direction > 0 ? t > to : t < to; t -= step) {
+    for (var point, t = from; direction > 0 ? t > to : t < to; t -= step) {
       listener.point((point = d3_geo_spherical([
         cr,
         -sr * Math.cos(t),

--- a/test/geo/circle-test.js
+++ b/test/geo/circle-test.js
@@ -22,6 +22,10 @@ suite.addBatch({
       var o = circle().origin([45, 45]).angle(0)();
       assert.equal(o.type, "Polygon");
       assert.inDelta(o.coordinates[0][0], [45, 45], 1e-6);
+    },
+    "first and last points are coincident": function(circle) {
+      var o = circle().origin([0, 0]).angle(.02).precision(45)();
+      assert.inDelta(o.coordinates[0][0], o.coordinates[0].pop(), 1e-6);
     }
   }
 });


### PR DESCRIPTION
Due to floating point rounding error, d3.geo.circle would sometimes miss
out the end point, which should be coincident with the start point.

Fixes #1476.
