### PR TITLE
Round step value in d3_scale_linearTickRange to fixed precision to prevent rounding issues on Windows Phone devices

### DIFF
--- a/src/scale/linear.js
+++ b/src/scale/linear.js
@@ -95,9 +95,13 @@ function d3_scale_linearTickRange(domain, m) {
 
   var extent = d3_scaleExtent(domain),
       span = extent[1] - extent[0],
-      step = Math.pow(10, Math.floor(Math.log(span / m) / Math.LN10)),
+	  exponent = Math.floor(Math.log(span / m) / Math.LN10),
+      step = Math.pow(10, exponent),
       err = m / span * step;
 
+  //Round step to fixed length to prevent rounding issues on Windows Phone devices	  
+  if ((exponent < 0) && ( exponent > 20)) step = +(step.toFixed(-exponent));
+  
   // Filter ticks to get closer to the desired count.
   if (err <= .15) step *= 10;
   else if (err <= .35) step *= 5;


### PR DESCRIPTION
The following issue occured on a HTC Windows Phone 8S running the latest version of Windows Phone 8. 

When using the function Math.pow, the resulting values are slightly off the correct values for specific input parameters. That means while Math.pow(10,0), Math.pow(10,2) or Math.pow(10,3) correctly return 1, 0.01 and 0.001, Math.pow(10,1) results in 0.09999999999999 instead of 0.1. You can test this behaviour here (with an appropriate device): http://jsbin.com/IbEvAKO/1

I could only reproduce this issue on the HTC Windows Phone 8S but other Windows Phone devices or smartphones in general might be vulnerable to this issue.

The difference between the correct and the returned value might seem minor, but it somehow breaks parts of d3 which use the ticks of linear scales, e.g. axis. If axis lie within a range where the Math.pow value is off, the axis ticks will not be displayed at all.

My proposed fix just converts the step value to a fixed size string and then back to Number. Because the step value is always an exponentiation with a base of 10, no precision is lost during the conversion.
