### PR TITLE
Added `padding` to `d3.layout.pie`

### DIFF
--- a/src/layout/pie.js
+++ b/src/layout/pie.js
@@ -6,27 +6,42 @@ import "layout";
 d3.layout.pie = function() {
   var value = Number,
       sort = d3_layout_pieSortByValue,
+      padding = 0,
       startAngle = 0,
       endAngle = 2 * π;
 
   function pie(data) {
+    var len = data.length;
 
     // Compute the numeric values for each data element.
     var values = data.map(function(d, i) { return +value.call(pie, d, i); });
+
+    // Compute padding if there is more than one arc.
+    var p = len > 1 ? (
+          +(typeof padding === "function"
+          ? padding.apply(this, arguments)
+          : padding)
+        )
+        : 0;
+
+    //Compute the number of spaces we have to layout.
+    //If the startAngle and endAngle represents a circle, we use a space after each arc.
+    //If it's not a circle, each arc except for the last one gets a space after it.
+    var spaceCount = endAngle - startAngle === 2 * π ? len : len - 1;
 
     // Compute the start angle.
     var a = +(typeof startAngle === "function"
         ? startAngle.apply(this, arguments)
         : startAngle);
 
-    // Compute the angular scale factor: from value to radians.
+    // Compute the angular scale factor: from value to radians subtracting padding (if set).
     var k = ((typeof endAngle === "function"
         ? endAngle.apply(this, arguments)
-        : endAngle) - a)
+        : endAngle) - a - p * spaceCount)
         / d3.sum(values);
 
     // Optionally sort the data.
-    var index = d3.range(data.length);
+    var index = d3.range(len);
     if (sort != null) index.sort(sort === d3_layout_pieSortByValue
         ? function(i, j) { return values[j] - values[i]; }
         : function(i, j) { return sort(data[i], data[j]); });
@@ -42,6 +57,8 @@ d3.layout.pie = function() {
         startAngle: a,
         endAngle: a += d * k
       };
+      //Add padding.
+      a += p;
     });
     return arcs;
   }
@@ -66,6 +83,22 @@ d3.layout.pie = function() {
   pie.sort = function(x) {
     if (!arguments.length) return sort;
     sort = x;
+    return pie;
+  };
+
+
+  /**
+   * Specifies the padding in degrees between each arc. Defaults to 0. The
+   * padding can be specified either as a constant or as a function; in the
+   * case of a function, it is evaluated once per array (as opposed to per
+   * element).
+   * If the pie is a circle (endAngle - startAngle = 2π) a space is laid out
+   * after each segment. If it's not a circle each arc except the last one
+   * will have a space after it.
+   */
+  pie.padding = function(x) {
+    if (!arguments.length) return padding;
+    padding = x;
     return pie;
   };
 

--- a/test/layout/pie-test.js
+++ b/test/layout/pie-test.js
@@ -4,6 +4,10 @@ var vows = require("vows"),
 
 var suite = vows.describe("d3.layout.pie");
 
+function round(n) {
+    return Math.round(n * 1000000000000) / 1000000000000;
+}
+
 suite.addBatch({
   "pie": {
     topic: load("layout/pie").expression("d3.layout.pie"),
@@ -16,6 +20,85 @@ suite.addBatch({
         84, 90, 48, 61, 58, 8, 6, 31, 45, 18
       ]).map(function(d) { return d.data; }), [
         84, 90, 48, 61, 58, 8, 6, 31, 45, 18
+      ]);
+    },
+    "can compute arcs for circle without padding": function(pie) {
+      var dataDeg = 2*Math.PI;
+      var p = pie()
+          .sort(null);
+      assert.deepEqual(p([5, 30, 15]).map(function(d) { return {s: round(d.startAngle), e: round(d.endAngle)}; }), [
+        {
+          s: 0,
+          e: round(5/50 * dataDeg)
+        },
+        {
+          s: round(5/50 * dataDeg),
+          e: round(35/50 * dataDeg)
+        },
+        {
+          s: round(35/50 * dataDeg),
+          e: round(dataDeg)
+        }
+      ]);
+    },
+    "can layout padding after each arc in a circle": function(pie) {
+      var padding = 0.1;
+      var dataDeg = 2*Math.PI - 3*padding;
+      var p = pie()
+          .sort(null)
+          .padding(padding);
+      assert.deepEqual(p([5, 30, 15]).map(function(d) { return {s: round(d.startAngle), e: round(d.endAngle)}; }), [
+        {
+          s: 0,
+          e: round(5/50 * dataDeg)
+        },
+        {
+          s: round(5/50 * dataDeg + padding),
+          e: round(35/50 * dataDeg + padding)
+        },
+        {
+          s: round(35/50 * dataDeg + 2*padding),
+          e: round(2*Math.PI - padding)
+        }
+      ]);
+    },
+    "can ignore padding when there is only one arc": function(pie) {
+      var p = pie()
+          .sort(null)
+          .padding(0.5);
+      assert.deepEqual(p([5]).map(function(d) { return {s: round(d.startAngle), e: round(d.endAngle)}; }), [
+        {
+          s: 0,
+          e: round(2*Math.PI)
+        }
+      ]);
+    },
+    "can return empty array when there are no arcs": function(pie) {
+      var p = pie()
+          .sort(null)
+          .padding(0.5);
+      assert.deepEqual(p([]), []);
+    },
+    "can layout spaces after each arc except the last one in a semicircle": function(pie) {
+      var padding = 0.1;
+      var dataDeg = Math.PI - 2*padding;
+      var p = pie()
+          .sort(null)
+          .endAngle(Math.PI)
+          .padding(padding);
+      assert.deepEqual(p([5, 30, 15]).map(function(d) { return {s: round(d.startAngle), e: round(d.endAngle)}; }), [
+        {
+          s: 0,
+          e: round(5/50 * dataDeg)
+        },
+        {
+          s: round(5/50 * dataDeg + padding),
+          e: round(35/50 * dataDeg + padding)
+        },
+        {
+          s: round(35/50 * dataDeg + 2*padding),
+          e: round(Math.PI)
+        }
       ]);
     }
   }


### PR DESCRIPTION
This is very handy instead of using `stroke-width`, which diminishes the visual value of small arcs in a pie/donut chart, and might intersect with other shapes in the chart. The spacing that each arc gets does not count against its value.

Example:

``` javascript
pie = d3.layout.pie()
        .spacing(2 * Math.PI * 0.01); //Each arc gets a spacer of 1% of the circle's size after it
```

![Example](http://i.imgur.com/jiUk48t.png)
