### PR TITLE
Allow min/max to be used as high order functions

### DIFF
--- a/src/arrays/max.js
+++ b/src/arrays/max.js
@@ -3,7 +3,7 @@ d3.max = function(array, f) {
       n = array.length,
       a,
       b;
-  if (arguments.length === 1) {
+  if (typeof f !== 'function') {
     while (++i < n && !((a = array[i]) != null && a <= a)) a = undefined;
     while (++i < n) if ((b = array[i]) != null && b > a) a = b;
   } else {

--- a/src/arrays/min.js
+++ b/src/arrays/min.js
@@ -3,7 +3,7 @@ d3.min = function(array, f) {
       n = array.length,
       a,
       b;
-  if (arguments.length === 1) {
+  if (typeof f !== 'function') {
     while (++i < n && !((a = array[i]) != null && a <= a)) a = undefined;
     while (++i < n) if ((b = array[i]) != null && a > b) a = b;
   } else {

--- a/test/arrays/max-test.js
+++ b/test/arrays/max-test.js
@@ -44,6 +44,12 @@ suite.addBatch({
     "applies the optional accessor function": function(max) {
       assert.equal(max([[1, 2, 3, 4, 5], [2, 4, 6, 8, 10]], function(d) { return _.min(d); }), 2);
       assert.equal(max([1, 2, 3, 4, 5], function(d, i) { return i; }), 4);
+    },
+    "ignores the secord argment if not a function": function(max) {
+      assert.equal(max([3, 20],0), 20);
+    },
+    "can call itself as the optional accessor": function(max) {
+      assert.equal(max([[1,2],[3,4]],max),4);
     }
   }
 });

--- a/test/arrays/min-test.js
+++ b/test/arrays/min-test.js
@@ -44,6 +44,12 @@ suite.addBatch({
     "applies the optional accessor function": function(min) {
       assert.equal(min([[1, 2, 3, 4, 5], [2, 4, 6, 8, 10]], function(d) { return _.max(d); }), 5);
       assert.equal(min([1, 2, 3, 4, 5], function(d, i) { return i; }), 0);
+    },
+    "ignores the secord argment if not a function": function(min) {
+      assert.equal(min([3, 20],0), 3);
+    },
+    "can call itself as the optional accessor": function(min) {
+      assert.equal(min([[1,2],[3,4]],min),1);
     }
   }
 });


### PR DESCRIPTION
Right now d3.min and d3.min require a little extra work if you have nested arrays. This PR requires that the second argument to these functions be a function, before it is called as an accessor.  This allows you to do things like `twoLevelArray.map(d3.min)` or `d3.min(twoLevelArray,d3.max)`.