### PR TITLE
Use [] instead of charAt

### DIFF
--- a/src/color/rgb.js
+++ b/src/color/rgb.js
@@ -97,11 +97,11 @@ function d3_rgb_parse(format, rgb, hsl) {
   if (name = d3_rgb_names.get(format)) return rgb(name.r, name.g, name.b);
 
   /* Hexadecimal colors: #rgb and #rrggbb. */
-  if (format != null && format.charAt(0) === "#") {
+  if (format != null && format[0] === "#") {
     if (format.length === 4) {
-      r = format.charAt(1); r += r;
-      g = format.charAt(2); g += g;
-      b = format.charAt(3); b += b;
+      r = format[1]; r += r;
+      g = format[2]; g += g;
+      b = format[3]; b += b;
     } else if (format.length === 7) {
       r = format.substring(1, 3);
       g = format.substring(3, 5);
@@ -151,7 +151,7 @@ function d3_rgb_xyz(r) {
 
 function d3_rgb_parseNumber(c) { // either integer or percentage
   var f = parseFloat(c);
-  return c.charAt(c.length - 1) === "%" ? Math.round(f * 2.55) : f;
+  return c[c.length - 1] === "%" ? Math.round(f * 2.55) : f;
 }
 
 var d3_rgb_names = d3.map({

--- a/src/core/vendor.js
+++ b/src/core/vendor.js
@@ -2,7 +2,7 @@ import "document";
 
 function d3_vendorSymbol(object, name) {
   if (name in object) return name;
-  name = name.charAt(0).toUpperCase() + name.substring(1);
+  name = name[0].toUpperCase() + name.substring(1);
   for (var i = 0, n = d3_vendorPrefixes.length; i < n; ++i) {
     var prefixName = d3_vendorPrefixes[i] + name;
     if (prefixName in object) return prefixName;

--- a/src/time/format.js
+++ b/src/time/format.js
@@ -21,7 +21,7 @@ function d3_time_format(template) {
     while (++i < n) {
       if (template.charCodeAt(i) === 37) {
         string.push(template.substring(j, i));
-        if ((p = d3_time_formatPads[c = template.charAt(++i)]) != null) c = template.charAt(++i);
+        if ((p = d3_time_formatPads[c = template[++i]]) != null) c = template[++i];
         if (f = d3_time_formats[c]) c = f(date, p == null ? (c === "e" ? " " : "0") : p);
         string.push(c);
         j = i + 1;
@@ -77,8 +77,8 @@ function d3_time_parse(date, template, string, j) {
     if (j >= m) return -1;
     c = template.charCodeAt(i++);
     if (c === 37) {
-      t = template.charAt(i++);
-      p = d3_time_parsers[t in d3_time_formatPads ? template.charAt(i++) : t];
+      t = template[i++];
+      p = d3_time_parsers[t in d3_time_formatPads ? template[i++] : t];
       if (!p || ((j = p(date, string, j)) < 0)) return -1;
     } else if (c != string.charCodeAt(j++)) {
       return -1;


### PR DESCRIPTION
Replace `charAt` calls with `[]`.
Index lookup is ~10% faster and saves a few bytes.
