### PR TITLE
Set context of callback to data, up one level

### DIFF
--- a/src/layout/stack.js
+++ b/src/layout/stack.js
@@ -16,13 +16,13 @@ d3.layout.stack = function() {
 
     // Convert series to canonical two-dimensional representation.
     var series = data.map(function(d, i) {
-      return values.call(stack, d, i);
+      return values.call(this, d, i);
     });
 
     // Convert each series to canonical [[x,y]] representation.
     var points = series.map(function(d) {
       return d.map(function(v, i) {
-        return [x.call(stack, v, i), y.call(stack, v, i)];
+        return [x.call(this, v, i), y.call(this, v, i)];
       });
     });
 
@@ -41,9 +41,9 @@ d3.layout.stack = function() {
         j,
         o;
     for (j = 0; j < m; ++j) {
-      out.call(stack, series[0][j], o = offsets[j], points[0][j][1]);
+      out.call(series[0], series[0][j], o = offsets[j], points[0][j][1]);
       for (i = 1; i < n; ++i) {
-        out.call(stack, series[i][j], o += points[i - 1][j][1], points[i][j][1]);
+        out.call(series[i], series[i][j], o += points[i - 1][j][1], points[i][j][1]);
       }
     }
 


### PR DESCRIPTION
Instead of setting the context to the stack function. Instead set it up one level in the data hierarchy.

So, for example, you could have data like:

```
var layers = [
  {
    "name": "apples",
    "values": [
      { "x": 0, "y":  91},
      { "x": 1, "y": 290}
    ]
  },
  {  
    "name": "oranges",
    "values": [
      { "x": 0, "y":  9},
      { "x": 1, "y": 49}
    ]
  }
];
```

And you set .values `function(d) {return d.values;}`

Then `.y` could reference the `names` with `this.names`
