### PR TITLE
add jspm package.json config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
   },
   "main": "index.js",
   "browserify": "index-browserify.js",
+  "jspm": {
+    "main": "d3.js",
+    "files": ["d3.js"],
+    "buildConfig": { "uglify": true }
+  },
   "jam": {
     "main": "d3.js",
     "shim": {


### PR DESCRIPTION
With this configuration in the package.json, it will allow d3 to be loaded through jspm as easily as:

http://jsbin.com/uVAxOvah/2/edit

Including minification with source maps.

It would be great to have this included if possible. Any questions just ask.
