### PR TITLE
Use `inDelta` not `equals` for double comparisons in polygon area test

### DIFF
--- a/test/geo/area-test.js
+++ b/test/geo/area-test.js
@@ -47,7 +47,7 @@ suite.addBatch({
         assert.inDelta(area({type: "Polygon", coordinates: [[[0, 0], [0, 90], [90, 0], [0, 0]]]}), π / 2, 1e-6);
       },
       "lune": function(area) {
-        assert.equal(area({type: "Polygon", coordinates: [[[0, 0], [0, 90], [90, 0], [0, -90], [0, 0]]]}), π);
+        assert.inDelta(area({type: "Polygon", coordinates: [[[0, 0], [0, 90], [90, 0], [0, -90], [0, 0]]]}), π, 1e-6);
       },
       "hemispheres": {
         "North": function(area) {
@@ -57,10 +57,10 @@ suite.addBatch({
           assert.inDelta(area({type: "Polygon", coordinates: [[[0, 0], [90, 0], [180, 0], [-90, 0], [0, 0]]]}), 2 * π, 1e-6);
         },
         "East": function(area) {
-          assert.equal(area({type: "Polygon", coordinates: [[[0, 0], [0, 90], [180, 0], [0, -90], [0, 0]]]}), 2 * π);
+          assert.inDelta(area({type: "Polygon", coordinates: [[[0, 0], [0, 90], [180, 0], [0, -90], [0, 0]]]}), 2 * π, 1e-6);
         },
         "West": function(area) {
-          assert.equal(area({type: "Polygon", coordinates: [[[0, 0], [0, -90], [180, 0], [0, 90], [0, 0]]]}), 2 * π);
+          assert.inDelta(area({type: "Polygon", coordinates: [[[0, 0], [0, -90], [180, 0], [0, 90], [0, 0]]]}), 2 * π, 1e-6);
         }
       },
       "graticule outline": {


### PR DESCRIPTION
Fixes this:

```
    area Polygon
      ✗ lune
        » expected 3.141592653589793,
        got  3.1415926535897927 (==) // area-test.js:50
  ✗ Broken » 2546 honored ∙ 1 broken (9.349s)
  npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
