### PR TITLE
Make jsdom an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "exports": "d3"
     }
   },
-  "dependencies": {
+  "optionalDependencies": {
     "jsdom": "0.5.7"
   },
   "devDependencies": {


### PR DESCRIPTION
The rationale is that many people use NPM to install dependencies for browser apps (not Node ones), and `jsdom` is a problematic dependency because it requires Xcode instead of just command-line-tools on OS X.
