### PR TITLE
Use browserified index.js for bower

### DIFF
--- a/bin/bower
+++ b/bin/bower
@@ -5,9 +5,9 @@ var fs = require("fs");
 console.log(JSON.stringify({
   "name": "d3",
   "version": require("../package.json").version,
-  "main": "d3.js",
+  "main": "index-browserify.js",
   "scripts": [
-    "d3.js"
+    "index-browserify.js"
   ],
   "ignore": [
     ".DS_Store",
@@ -18,7 +18,6 @@ console.log(JSON.stringify({
     "Makefile",
     "bin",
     "component.json",
-    "index-browserify.js",
     "index.js",
     "lib",
     "node_modules",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "d3",
   "version": "3.3.13",
-  "main": "d3.js",
+  "main": "index-browserify.js",
   "scripts": [
     "index-browserify.js"
   ],


### PR DESCRIPTION
I might be completely mistaken since I still struggle with definitions and combinations of `npm`, `bower`, `component` and all the other things in frontend JavaScript. However, when using `d3` with `bower`, only an empty object is returned from a `require("d3")` and indeed, there is only a `return d3` in `d3.js` instead of Node-style `module.exports = d3`. The latter is done with `index-browserify.js` and it seems logical to me to use that for `bower`.

(I've just noticed that I also have to update `bin/bower`, will do so immediately and update the pull request)
