### PR TITLE
Fix for singleton ordinal domains

### DIFF
--- a/src/scale/ordinal.js
+++ b/src/scale/ordinal.js
@@ -12,7 +12,15 @@ function d3_scale_ordinal(domain, ranger) {
       rangeBand;
 
   function scale(x) {
-    return range[((index.get(x) || ranger.t === "range" && index.set(x, domain.push(x))) - 1) % range.length];
+    var i = index.get(x);
+    if (!i)
+      if (ranger.t === "range")
+	i = index.set(x, domain.push(x));
+    var rangeVal;
+    if (i) {
+      rangeVal = range[(i - 1) % range.length];
+    }
+    return rangeVal;
   }
 
   function steps(start, step) {

--- a/test/scale/ordinal-test.js
+++ b/test/scale/ordinal-test.js
@@ -117,6 +117,7 @@ suite.addBatch({
       "correctly handles singleton domains": function(ordinal) {
         var x = ordinal().domain(["a"]).rangePoints([0, 120]);
         assert.deepEqual(x.range(), [60]);
+	assert.isUndefined(x('b'));
       },
       "can be set to a descending range": function(ordinal) {
         var x = ordinal().domain(["a", "b", "c"]).rangePoints([120, 0]);


### PR DESCRIPTION
If an ordinal scale has a singleton domain and the range uses rangePoints or rangeBands, then all non-members of the domain will be mapped to the singleton member.  They should be mapped to undefined instead.

[Also:  The logic for returning the range given a domain value relied on javascript modulo returning NaN if the range is empty, and has the side effect that a "-1" property is added to the range for rangePoints/rangeBands ordinals where a non-domain member is mapped.  Seems unlikely that anything actually relies on that behavior but I didn't try to clean it up just to be safe.  Because of that, though, the code is still a little opaque, at least to me.]
