### PR TITLE
pass in extra arguments to time.format.multi predicate functions

### DIFF
--- a/src/locale/time-format.js
+++ b/src/locale/time-format.js
@@ -363,7 +363,7 @@ function d3_time_formatMulti(formats) {
   while (++i < n) formats[i][0] = this(formats[i][0]);
   return function(date) {
     var i = 0, f = formats[i];
-    while (!f[1](date)) f = formats[++i];
+    while (!f[1].apply(this, arguments)) f = formats[++i];
     return f[0](date);
   };
 }

--- a/test/time/format-test.js
+++ b/test/time/format-test.js
@@ -202,6 +202,19 @@ suite.addBatch({
       }
     },
 
+    "multi with arguments": {
+      topic: function(format) {
+        return format.multi([
+          ["one passed in", function(d, arg) { return arg === "one"; }],
+          ["two passed in", function(d, arg) { return arg === "two"; }]
+        ]);
+      },
+      "passes extra arguments to predicate": function(f) {
+        assert.equal(f(local(1990, 0, 1, 1), "one"), "one passed in");
+        assert.equal(f(local(1990, 0, 1, 1), "two"), "two passed in");
+      }
+    },
+
     "parse": {
       "parses abbreviated weekday and numeric date": function(format) {
         var p = format("%a %m/%d/%Y").parse;


### PR DESCRIPTION
To be able to do something like this:

``` javascript
var format = d3.format.multi([
    ['%Y',         function(d, resolution) { return resolution === 'year'; }],
    ['%b, %Y',     function(d, resolution) { return resolution === 'month'; }],
    ['%-d %b, %Y', function()              { return true; }]
]);
format(date, 'month');
```

The performance and file size impact (+ 19 chars when minified) is minimal and it's 100% backwards compatible.
