### PR TITLE
Define "d3", not an anonymous module.

### DIFF
--- a/src/end.js
+++ b/src/end.js
@@ -1,5 +1,5 @@
   if (typeof define === "function" && define.amd) {
-    define(d3);
+    define("d3", d3);
   } else if (typeof module === "object" && module.exports) {
     module.exports = d3;
   } else {


### PR DESCRIPTION
almond.js will choke on anonymous modules, hence

```
define(function() {})
```

should look like this instead:

```
define("someName", function() {})
```

More information here: https://github.com/jrburke/almond#common-errors
