### PR TITLE
Fix quadtree tests that check the children of a node

### DIFF
--- a/test/geom/quadtree-test.js
+++ b/test/geom/quadtree-test.js
@@ -29,10 +29,10 @@ suite.addBatch({
             n = 0;
         q.visit(function(node, x1, y1, x2, y2) {
           assert.deepEqual(node.point, point);
-          assert.isUndefined(node[0]);
-          assert.isUndefined(node[1]);
-          assert.isUndefined(node[2]);
-          assert.isUndefined(node[3]);
+          assert.isUndefined(node.nodes[0]);
+          assert.isUndefined(node.nodes[1]);
+          assert.isUndefined(node.nodes[2]);
+          assert.isUndefined(node.nodes[3]);
           assert.isTrue(node.leaf);
           ++n;
         });
@@ -46,10 +46,10 @@ suite.addBatch({
             n = 0;
         q.visit(function(node, x1, y1, x2, y2) {
           assert.deepEqual(node.point, point);
-          assert.isUndefined(node[0]);
-          assert.isUndefined(node[1]);
-          assert.isUndefined(node[2]);
-          assert.isUndefined(node[3]);
+          assert.isUndefined(node.nodes[0]);
+          assert.isUndefined(node.nodes[1]);
+          assert.isUndefined(node.nodes[2]);
+          assert.isUndefined(node.nodes[3]);
           assert.isTrue(node.leaf);
           ++n;
         });
@@ -60,10 +60,10 @@ suite.addBatch({
             n = 0;
         q.visit(function(node, x1, y1, x2, y2) {
           assert.isNull(node.point);
-          assert.isUndefined(node[0]);
-          assert.isUndefined(node[1]);
-          assert.isUndefined(node[2]);
-          assert.isUndefined(node[3]);
+          assert.isUndefined(node.nodes[0]);
+          assert.isUndefined(node.nodes[1]);
+          assert.isUndefined(node.nodes[2]);
+          assert.isUndefined(node.nodes[3]);
           assert.isTrue(node.leaf);
           ++n;
         });


### PR DESCRIPTION
Currently, the quadtree tests try to check the children of a node like so:

```
assert.isUndefined(node[2]);
```

However, node is the result of d3_geom_quadtreeNode, not an array, so that assert is just checking the '2' property of the node object, which, indeed happens to be undefined.

I think these tests mean to check the `nodes` property of the node, which _is_ an array, so this updates those statements like so:

```
assert.isUndefined(node.nodes[2]);
```
