### PR TITLE
Correct instances of '+ +' and '+ -' to protect from minification errors...

### DIFF
--- a/src/event/drag.js
+++ b/src/event/drag.js
@@ -6,7 +6,7 @@ var d3_event_dragSelect = "onselectstart" in d3_document ? null : d3_vendorSymbo
     d3_event_dragId = 0;
 
 function d3_event_dragSuppress() {
-  var name = ".dragsuppress-" + ++d3_event_dragId,
+  var name = ".dragsuppress-" + (++d3_event_dragId),
       click = "click" + name,
       w = d3.select(d3_window)
           .on("touchmove" + name, d3_eventPreventDefault)

--- a/src/geo/path-buffer.js
+++ b/src/geo/path-buffer.js
@@ -53,7 +53,7 @@ function d3_geo_pathBuffer() {
 
 function d3_geo_pathBufferCircle(radius) {
   return "m0," + radius
-      + "a" + radius + "," + radius + " 0 1,1 0," + -2 * radius
-      + "a" + radius + "," + radius + " 0 1,1 0," + 2 * radius
+      + "a" + radius + "," + radius + " 0 1,1 0," + (-2 * radius)
+      + "a" + radius + "," + radius + " 0 1,1 0," + (2 * radius)
       + "z";
 }

--- a/src/scale/linear.js
+++ b/src/scale/linear.js
@@ -153,6 +153,6 @@ function d3_scale_linearPrecision(value) {
 function d3_scale_linearFormatPrecision(type, range) {
   var p = d3_scale_linearPrecision(range[2]);
   return type in d3_scale_linearFormatSignificant
-      ? Math.abs(p - d3_scale_linearPrecision(Math.max(abs(range[0]), abs(range[1])))) + +(type !== "e")
+      ? Math.abs(p - d3_scale_linearPrecision(Math.max(abs(range[0]), abs(range[1])))) + (+(type !== "e"))
       : p - (type === "%") * 2;
 }

--- a/src/svg/axis.js
+++ b/src/svg/axis.js
@@ -65,7 +65,7 @@ d3.svg.axis = function() {
           lineUpdate.attr("x2", 0).attr("y2", -innerTickSize);
           textUpdate.attr("x", 0).attr("y", -(Math.max(innerTickSize, 0) + tickPadding));
           text.attr("dy", "0em").style("text-anchor", "middle");
-          pathUpdate.attr("d", "M" + range[0] + "," + -outerTickSize + "V0H" + range[1] + "V" + -outerTickSize);
+          pathUpdate.attr("d", "M" + range[0] + "," + (-outerTickSize) + "V0H" + range[1] + "V" + (-outerTickSize));
           break;
         }
         case "left": {
@@ -75,7 +75,7 @@ d3.svg.axis = function() {
           lineUpdate.attr("x2", -innerTickSize).attr("y2", 0);
           textUpdate.attr("x", -(Math.max(innerTickSize, 0) + tickPadding)).attr("y", 0);
           text.attr("dy", ".32em").style("text-anchor", "end");
-          pathUpdate.attr("d", "M" + -outerTickSize + "," + range[0] + "H0V" + range[1] + "H" + -outerTickSize);
+          pathUpdate.attr("d", "M" + (-outerTickSize) + "," + range[0] + "H0V" + range[1] + "H" + (-outerTickSize));
           break;
         }
         case "right": {

--- a/src/svg/chord.js
+++ b/src/svg/chord.js
@@ -45,7 +45,7 @@ d3.svg.chord = function() {
   }
 
   function arc(r, p, a) {
-    return "A" + r + "," + r + " 0 " + +(a > π) + ",1 " + p;
+    return "A" + r + "," + r + " 0 " + (+(a > π)) + ",1 " + p;
   }
 
   function curve(r0, p0, r1, p1) {

--- a/src/svg/symbol.js
+++ b/src/svg/symbol.js
@@ -50,51 +50,51 @@ var d3_svg_symbols = d3.map({
   "circle": d3_svg_symbolCircle,
   "cross": function(size) {
     var r = Math.sqrt(size / 5) / 2;
-    return "M" + -3 * r + "," + -r
-        + "H" + -r
-        + "V" + -3 * r
+    return "M" + (-3) * r + "," + (-r)
+        + "H" + (-r)
+        + "V" + (-3) * r
         + "H" + r
-        + "V" + -r
+        + "V" + (-r)
         + "H" + 3 * r
         + "V" + r
         + "H" + r
         + "V" + 3 * r
-        + "H" + -r
+        + "H" + (-r)
         + "V" + r
-        + "H" + -3 * r
+        + "H" + (-3) * r
         + "Z";
   },
   "diamond": function(size) {
     var ry = Math.sqrt(size / (2 * d3_svg_symbolTan30)),
         rx = ry * d3_svg_symbolTan30;
-    return "M0," + -ry
+    return "M0," + (-ry)
         + "L" + rx + ",0"
         + " 0," + ry
-        + " " + -rx + ",0"
+        + " " + (-rx) + ",0"
         + "Z";
   },
   "square": function(size) {
     var r = Math.sqrt(size) / 2;
-    return "M" + -r + "," + -r
-        + "L" + r + "," + -r
+    return "M" + (-r) + "," + (-r)
+        + "L" + r + "," + (-r)
         + " " + r + "," + r
-        + " " + -r + "," + r
+        + " " + (-r) + "," + r
         + "Z";
   },
   "triangle-down": function(size) {
     var rx = Math.sqrt(size / d3_svg_symbolSqrt3),
         ry = rx * d3_svg_symbolSqrt3 / 2;
     return "M0," + ry
-        + "L" + rx +"," + -ry
-        + " " + -rx + "," + -ry
+        + "L" + rx +"," + (-ry)
+        + " " + (-rx) + "," + (-ry)
         + "Z";
   },
   "triangle-up": function(size) {
     var rx = Math.sqrt(size / d3_svg_symbolSqrt3),
         ry = rx * d3_svg_symbolSqrt3 / 2;
-    return "M0," + -ry
+    return "M0," + (-ry)
         + "L" + rx +"," + ry
-        + " " + -rx + "," + ry
+        + " " + (-rx) + "," + ry
         + "Z";
   }
 });


### PR DESCRIPTION
I'm working on an app that will include d3 for a data visualization piece. Our process of minifying d3.js into our app was causing several 'Invalid left-hand side expression in postfix operation' errors caused by sequences of '+ +' and '+ -'. In order to avoid this issue, wrapping the modified variables in parenthesis prevents '+ ++' from becoming '+++' and '+ -' from becoming '+-' in the minified code and resolves the issue.

There is no functional change to the library in this update; it's simply a slight syntax change.
