### PR TITLE
Add spm support

### DIFF
--- a/.spmignore
+++ b/.spmignore
@@ -1,0 +1,4 @@
+bin
+lib
+src
+test

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
       "exports": "d3"
     }
   },
+  "spm": {
+    "main": "d3.js"
+  },
   "dependencies": {
     "jsdom": "0.5.7"
   },


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/d3

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of d3 in spmjs, I can add it for your account after signing in http://spmjs.io.
