### PR TITLE
re-did hierarchy to have flare.json based tests.

### DIFF
--- a/test/layout/hierarchy-test.js
+++ b/test/layout/hierarchy-test.js
@@ -8,11 +8,12 @@ suite.addBatch({
   "hierarchy": {
     topic: load("layout/treemap").expression("d3.layout.treemap"), // hierarchy is abstract, so test a subclass
     "doesn't overwrite the value of a node that has an empty children array": function(hierarchy) {
-      var h = hierarchy(),
-          nodes = h.sticky(true).nodes({value: 1, children: []});
-      assert.equal(nodes[0].value, 1);
-      h.nodes(nodes[0]);
-      assert.equal(nodes[0].value, 1);
+      var h = hierarchy().sticky(true).children(function(d) {return d.children;}),
+        nodes = h.nodes({"name":"flare","children":[{"name":"analytics","children":[{"name":"cluster","children":[{"name":"AgglomerativeCluster","size":3938},{"name":"CommunityStructure","size":3812},{"name":"MergeEdge","size":743}]},{"name":"graph","children":[{"name":"BetweennessCentrality","size":3534},{"name":"LinkDistance","size":5731}]}]}]});
+      assert.equal(nodes[0].name, "flare");
+      h(nodes[0]); // calls hierarchy.revalue
+      assert.equal(nodes[0].name, "flare");
+      assert.equal(nodes[0].children[0].name, "analytics");
     },
     "a valueless node that has an empty children array gets a value of 0": function(hierarchy) {
       var h = hierarchy(),
@@ -26,6 +27,13 @@ suite.addBatch({
           nodes = h.children(function() { return null; }).nodes({children: [{}]});
       assert.equal(nodes[0].value, 0);
       assert.isUndefined(nodes[0].children);
+    },
+    "revalue": function(hierarchy) {
+      var h = hierarchy().sticky(true),
+          nodes = h.nodes({"name":"flare","children":[{"name":"analytics","children":[{"name":"cluster","children":[{"name":"AgglomerativeCluster","size":3938},{"name":"CommunityStructure","size":3812},{"name":"MergeEdge","size":743}]},{"name":"graph","children":[{"name":"BetweennessCentrality","size":3534},{"name":"LinkDistance","size":5731}]}]}]});
+      assert.equal(nodes[0].name, "flare");
+      h(nodes[0]); // calls hierarchy.revalue
+      assert.equal(nodes[0].name, "flare");
     }
   }
 });


### PR DESCRIPTION
Updated the tests for hierarchy to have them be flare.json based as per #1888.

Not sure if the data should be inline or not.  