### PR TITLE
Avoid 'unsafe-eval' code to comply with C-S-P

### DIFF
--- a/src/dsv/dsv.js
+++ b/src/dsv/dsv.js
@@ -32,9 +32,13 @@ d3.dsv = function(delimiter, mimeType) {
     var o;
     return dsv.parseRows(text, function(row, i) {
       if (o) return o(row, i - 1);
-      var a = new Function("d", "return {" + row.map(function(name, i) {
-        return JSON.stringify(name) + ": d[" + i + "]";
-      }).join(",") + "}");
+      var a = function(d) {
+        var r = {};
+        row.forEach(function(name, i) {
+          r[name] = d[i];
+        });
+        return r;
+      }
       o = f ? function(row, i) { return f(a(row), i); } : a;
     });
   };


### PR DESCRIPTION
Content-Security-Policy does not allow eval-like mechanisms, unless the
'unsafe-eval' keyword is specified.

Fixes issue  #1904.
