### PR TITLE
Always expose D3 onto the environment global

### DIFF
--- a/src/end.js
+++ b/src/end.js
@@ -2,7 +2,7 @@
     define(d3);
   } else if (typeof module === "object" && module.exports) {
     module.exports = d3;
-  } else {
-    this.d3 = d3;
   }
+
+  this.d3 = d3;
 }();


### PR DESCRIPTION
With regards to #1689 adding AMD compatibility, it seemed odd to me that
D3 opt'd out of exposing itself globally for third-party plugins.

Within a discussion about this very problem, found here:
https://github.com/jakevdp/mpld3/issues/33#issuecomment-32101013

the argument is made that exposing the global defeats the point of
module systems.  I agree that module systems help avoid global
pollution, but that is not something I'd consider the point of module
systems, especially since they are registered in a global namespace
themselves.

This patch will fix third-party modules that are shimmed.
