### PR TITLE
Catch responseText errors when responseType !== 'text' || ''

### DIFF
--- a/src/xhr/xhr.js
+++ b/src/xhr/xhr.js
@@ -31,7 +31,8 @@ function d3_xhr(url, mimeType, response, callback) {
 
   function respond() {
     var status = request.status, result;
-    if (!status && request.responseText || status >= 200 && status < 300 || status === 304) {
+    var validResponseText = (request.responseType === "" || request.responseType === "text") && request.responseText;
+    if (!status && validResponseText || status >= 200 && status < 300 || status === 304) {
       try {
         result = response.call(xhr, request);
       } catch (e) {


### PR DESCRIPTION
d3.xhr tests `request.responseText` which throws an uncaught "InvalidStateError" exception if responseType is not the empty string or "text". ([spec](http://xhr.spec.whatwg.org/#the-responsetext-attribute))

See [this example](http://bl.ocks.org/gmaclennan/520b8ccf857a36db5cf3) (open the console to see uncaught error).

I think this PR should catch the error.
