### PR TITLE
Use zero-padded day of the month in DE+FR

### DIFF
--- a/src/locale/de-DE.js
+++ b/src/locale/de-DE.js
@@ -6,7 +6,7 @@ d3.locale.de_DE = d3.locale({
   grouping: [3],
   currency: ["", " €"],
   dateTime: "%A, der %e. %B %Y, %X",
-  date: "%e.%m.%Y",
+  date: "%d.%m.%Y",
   time: "%H:%M:%S",
   periods: ["AM", "PM"], // unused
   days: ["Sonntag", "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag"],

--- a/src/locale/fr-FR.js
+++ b/src/locale/fr-FR.js
@@ -6,7 +6,7 @@ d3.locale.fr_FR = d3.locale({
   grouping: [3],
   currency: ["", " €"],
   dateTime: "%A, le %e %B %Y, %X",
-  date: "%e/%m/%Y",
+  date: "%d/%m/%Y",
   time: "%H:%M:%S",
   periods: ["AM", "PM"], // unused
   days: ["dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi"],


### PR DESCRIPTION
Currently, dates get formatted as "1.01.2014" which is inconsistent.
Other locales use "01.01.2014" or comparable as well.
