### PR TITLE
adding multiple rollups to nest function w/ tests

### DIFF
--- a/src/arrays/nest.js
+++ b/src/arrays/nest.js
@@ -1,15 +1,16 @@
 import "map";
+import "entries";
 
 d3.nest = function() {
   var nest = {},
       keys = [],
       sortKeys = [],
       sortValues,
-      rollup;
+      rollups = [];
 
   function map(mapType, array, depth) {
-    if (depth >= keys.length) return rollup
-        ? rollup.call(nest, array) : (sortValues
+    if (depth >= keys.length) return rollups.length > 0
+        ? rollup(array) : (sortValues
         ? array.sort(sortValues)
         : array);
 
@@ -61,6 +62,18 @@ d3.nest = function() {
         : array;
   }
 
+  function rollup(array) {
+    return rollups
+      .map(function(g){return g(array)})
+      .reduce(
+        function(object,result,index,results) { 
+          d3.entries(result).length>0?
+          d3.entries(result).map(function(h){ object[h.key] = h.value })
+          :results.length>1?object[index] = result:object=result;
+          return object;
+      },{})
+  }
+
   nest.map = function(array, mapType) {
     return map(mapType, array, 0);
   };
@@ -89,7 +102,7 @@ d3.nest = function() {
   };
 
   nest.rollup = function(f) {
-    rollup = f;
+    rollups.push(f);
     return nest;
   };
 

--- a/test/arrays/nest-test.js
+++ b/test/arrays/nest-test.js
@@ -171,6 +171,26 @@ suite.addBatch({
         "2": 0
       });
     },
+    "values can be aggregated using multiple rollups": function(nest) {
+      var map = nest()
+          .key(function(d) { return d.foo; })
+          .rollup(function(values) { return _.sum(values, function(d) { return d.bar; }); })
+          .rollup(function(values) { return values.length })
+          .rollup(function(values) { return _.sum(values, function(d) { return d.foo; }); })
+          .map([{foo: 1, bar: 2}, {foo: 1, bar: 0}, {foo: 1, bar: 1}, {foo: 2}]);
+      assert.deepEqual(map, {
+      "1": { 
+          "0": 3,
+          "1": 3,
+          "2": 3
+        },
+      "2": {
+          "0": 0,
+          "1": 1,
+          "2": 2
+        }
+      });
+    },
     "multiple key functions can be specified": function(nest) {
       var map = nest()
           .key(function(d) { return d[0]; }).sortKeys(_.ascending)


### PR DESCRIPTION
I've modified the nest function to allow for multiple rollups to be specified, while maintaining the original functionality.  This simplifies dynamically adding rollups.  I updated Phoebe Bright's nest tutorial with some examples: http://bl.ocks.org/brett-miller/c31eb0c4d89ab84d6e22.