### PR TITLE
Fix multiple drag behaviours on single element

### DIFF
--- a/src/behavior/drag.js
+++ b/src/behavior/drag.js
@@ -6,7 +6,7 @@ import "../event/mouse";
 import "../event/touch";
 import "behavior";
 
-d3.behavior.drag = function() {
+d3.behavior.drag = function( event_id ) {
   var event = d3_eventDispatch(drag, "drag", "dragstart", "dragend"),
       origin = null,
       mousedown = dragstart(d3_noop, d3.mouse, d3_behavior_dragMouseSubject, "mousemove", "mouseup"),
@@ -25,7 +25,7 @@ d3.behavior.drag = function() {
           dispatch = event.of(that, arguments),
           dragged = 0,
           dragId = id(),
-          dragName = ".drag" + (dragId == null ? "" : "-" + dragId),
+          dragName = ".drag" + (event_id == null ? "" : "-" + event_id),
           dragOffset,
           dragSubject = d3.select(subject()).on(move + dragName, moved).on(end + dragName, ended),
           dragRestore = d3_event_dragSuppress(),


### PR DESCRIPTION
Hey! Not sure if there is a specific reason this didn't work before, but if you make these modifications you can have multiple drag behaviour like this:

    a = d3.behavior.drag('drag-a').on( ... );
    b = d3.behavior.drag('drag-b').on( ... );
    a.call(element);
    b.call(element);

If this is of any use for you I can compile the source files properly!