### PR TITLE
Skip creating half edges when we don't have a second vertex

### DIFF
--- a/src/geom/voronoi/cell.js
+++ b/src/geom/voronoi/cell.js
@@ -47,13 +47,16 @@ function d3_geom_voronoiCloseCells(extent) {
       end = halfEdges[iHalfEdge].end(), x3 = end.x, y3 = end.y;
       start = halfEdges[++iHalfEdge % nHalfEdges].start(), x2 = start.x, y2 = start.y;
       if (abs(x3 - x2) > ε || abs(y3 - y2) > ε) {
-        halfEdges.splice(iHalfEdge, 0, new d3_geom_voronoiHalfEdge(d3_geom_voronoiCreateBorderEdge(cell.site, end,
-            abs(x3 - x0) < ε && y1 - y3 > ε ? {x: x0, y: abs(x2 - x0) < ε ? y2 : y1}
-            : abs(y3 - y1) < ε && x1 - x3 > ε ? {x: abs(y2 - y1) < ε ? x2 : x1, y: y1}
-            : abs(x3 - x1) < ε && y3 - y0 > ε ? {x: x1, y: abs(x2 - x1) < ε ? y2 : y0}
-            : abs(y3 - y0) < ε && x3 - x0 > ε ? {x: abs(y2 - y0) < ε ? x2 : x0, y: y0}
-            : null), cell.site, null));
-        ++nHalfEdges;
+        var _vb = abs(x3 - x0) < ε && y1 - y3 > ε ? {x: x0, y: abs(x2 - x0) < ε ? y2 : y1}
+                : abs(y3 - y1) < ε && x1 - x3 > ε ? {x: abs(y2 - y1) < ε ? x2 : x1, y: y1}
+                : abs(x3 - x1) < ε && y3 - y0 > ε ? {x: x1, y: abs(x2 - x1) < ε ? y2 : y0}
+                : abs(y3 - y0) < ε && x3 - x0 > ε ? {x: abs(y2 - y0) < ε ? x2 : x0, y: y0}
+                : null;
+        if (_vb !== null) {
+          var edge = d3_geom_voronoiCreateBorderEdge(cell.site, end, _vb);
+          halfEdges.splice(iHalfEdge, 0, new d3_geom_voronoiHalfEdge(edge, cell.site, null));
+          ++nHalfEdges;
+        }
       }
     }
   }


### PR DESCRIPTION
Running into problems with voronoi use from with the nvd3 library, and while debugging I noticed that cascading conditional starting on line 51 of `cell.js` can end up with a `null` value, which causes `CreateBorderEdge` to choke de-referencing for an `x` value.

Not really understanding this code, it seems that we would not want to create a border edge in that case.

Is there any harm it just skipping its creation?

FWIW, the nvd3 code was fixed to remove duplicate points (see https://github.com/novus/nvd3/pull/584).

Thanks for any insights you can offer.