### PR TITLE
add d3.time.milliseconds to support millisecond resolution ticks

### DIFF
--- a/src/time/millisecond.js
+++ b/src/time/millisecond.js
@@ -1,0 +1,13 @@
+import "interval";
+import "time";
+
+d3_time.millisecond = d3_time_interval(function(date) {
+  return new d3_date(date);
+}, function(date, offset) {
+  date.setTime(date.getTime() + offset); // DST breaks setSeconds
+}, function(date) {
+  return date.getTime();
+});
+
+d3_time.milliseconds = d3_time.millisecond.range;
+d3_time.milliseconds.utc = d3_time.millisecond.utc.range;

--- a/test/time/millisecond-test.js
+++ b/test/time/millisecond-test.js
@@ -1,0 +1,143 @@
+var vows = require("vows"),
+    load = require("../load"),
+    assert = require("../assert"),
+    time = require("./time"),
+    local = time.local,
+    utc = time.utc;
+
+var suite = vows.describe("d3.time.millisecond");
+
+suite.addBatch({
+  "millisecond": {
+    topic: load("time/millisecond").expression("d3.time.millisecond"),
+    "defaults to floor": function(interval) {
+      assert.strictEqual(interval, interval.floor);
+    },
+    "floor": {
+      topic: function(interval) {
+        return interval.floor;
+      },
+      "returns seconds": function(floor) {
+        assert.deepEqual(floor(local(2010, 11, 31, 23, 59, 59, 999)), local(2010, 11, 31, 23, 59, 59, 999));
+        assert.deepEqual(floor(local(2011, 00, 01, 00, 00, 00, 000)), local(2011, 00, 01, 00, 00, 00, 000));
+        assert.deepEqual(floor(local(2011, 00, 01, 00, 00, 00, 001)), local(2011, 00, 01, 00, 00, 00, 001));
+      }
+    },
+    "round": {
+      topic: function(interval) {
+        return interval.round;
+      },
+      "returns seconds": function(round) {
+        assert.deepEqual(round(local(2010, 11, 31, 23, 59, 59, 999)), local(2010, 11, 31, 23, 59, 59, 999));
+        assert.deepEqual(round(local(2011, 00, 01, 00, 00, 00, 499)), local(2011, 00, 01, 00, 00, 00, 499));
+        assert.deepEqual(round(local(2011, 02011, 10, 6, 8, 59, 59, 0030, 01, 00, 00, 00, 500)), local(2011, 00, 01, 00, 00, 00, 500));
+      }
+    },
+    "ceil": {
+      topic: function(interval) {
+        return interval.ceil;
+      },
+      "returns seconds": function(ceil) {
+        assert.deepEqual(ceil(local(2010, 11, 31, 23, 59, 59, 999)), local(2010, 11, 31, 23, 59, 59, 999));
+        assert.deepEqual(ceil(local(2011, 00, 01, 00, 00, 00, 000)), local(2011, 00, 01, 00, 00, 00, 000));
+        assert.deepEqual(ceil(local(2011, 00, 01, 00, 00, 00, 001)), local(2011, 00, 01, 00, 00, 00, 001));
+      }
+    },
+    "offset": {
+      topic: function(interval) {
+        return interval.offset;
+      },
+      "does not modify the passed-in date": function(offset) {
+        var date = local(2010, 11, 31, 23, 52011, 10, 6, 8, 59, 59, 0039, 59, 999);
+        offset(date, +1);
+        assert.deepEqual(date, local(2010, 11, 31, 23, 59, 59, 999));
+      },
+      "does not round the passed-in-date": function(offset) {
+        assert.deepEqual(offset(local(2010, 11, 31, 23, 59, 59, 999), +1), local(2011, 00, 01, 00, 00, 00, 000));
+        assert.deepEqual(offset(local(2010, 11, 31, 23, 59, 59, 456), -2), local(2010, 11, 31, 23, 59, 59, 454));
+      },
+      "allows negative offsets": function(offset) {
+        assert.deepEqual(offset(local(2010, 11, 31, 23, 59, 59, 999), -1), local(2010, 11, 31, 23, 59, 59, 998));
+        assert.deepEqual(offset(local(2011, 00, 01, 00, 00, 00, 000), -2), local(2010, 11, 31, 23, 59, 59, 998));
+        assert.deepEqual(offset(local(2011, 00, 01, 00, 00, 00, 000), -1), local(2010, 11, 31, 23, 59, 59, 999));
+      },
+      "allows positive offsets": function(offset) {
+        assert.deepEqual(offset(local(2010, 11, 31, 23, 59, 58), +1), local(2010, 11, 31, 23, 59, 58, 001));
+        assert.deepEqual(offset(local(2010, 11, 31, 23, 59, 58), +2), local(2010, 11, 31, 23, 59, 58, 002));
+        assert.deepEqual(offset(local(2010, 11, 31, 23, 59, 59), +1), local(2010, 11, 31, 23, 59, 59, 001));
+      },
+      "allows zero offset": function(offset) {
+        assert.deepEqual(offset(local(2010, 11, 31, 23, 59, 59, 999), 0), local(2010, 11, 31, 23, 59, 59, 999));
+        assert.deepEqual(offset(local(2010, 11, 31, 23, 59, 58, 000), 0), local(2010, 11, 31, 23, 59, 58, 000));
+      }
+    },
+    "UTC": {
+      topic: function(interval) {
+        return interval.utc;
+      },
+      "defaults to floor": function(interval) {
+        assert.strictEqual(interval, interval.floor);
+      },
+      "floor": {
+        topic: function(interval) {
+          return interval.floor;
+        },
+        "returns milliseconds": function(floor) {
+          assert.deepEqual(floor(utc(2010, 11, 31, 23, 59, 59, 999)), utc(2010, 11, 31, 23, 59, 59, 999));
+          assert.deepEqual(floor(utc(2011, 00, 01, 00, 00, 00, 000)), utc(2011, 00, 01, 00, 00, 00));
+          assert.deepEqual(floor(utc(2011, 00, 01, 00, 00, 00, 001)), utc(2011, 00, 01, 00, 00, 00, 001));
+        }
+      },
+      "round": {
+        topic: function(interval) {
+          return interval.round;
+        },
+        "returns milliseconds": function(round) {
+          assert.deepEqual(round(utc(2010, 11, 31, 23, 59, 59, 999)), utc(2010, 11, 31, 23, 59, 59, 999));
+          assert.deepEqual(round(utc(2011, 00, 01, 00, 00, 00, 499)), utc(2011, 00, 01, 00, 00, 00, 499));
+          assert.deepEqual(round(utc(2011, 00, 01, 00, 00, 00, 500)), utc(2011, 00, 01, 00, 00, 00, 500));
+        }
+      },
+      "ceil": {
+        topic: function(interval) {
+          return interval.ceil;
+        },
+        "returns milliseconds": function(ceil) {
+          assert.deepEqual(ceil(utc(2010, 11, 31, 23, 59, 59, 999)), utc(2010, 11, 31, 23, 59, 59, 999));
+          assert.deepEqual(ceil(utc(2011, 00, 01, 00, 00, 00, 000)), utc(2011, 00, 01, 00, 00, 000));
+          assert.deepEqual(ceil(utc(2011, 00, 01, 00, 00, 00, 001)), utc(2011, 00, 01, 00, 00, 00, 001)); // strange
+        }
+      },
+      "offset": {
+        topic: function(interval) {
+          return interval.offset;
+        },
+        "does not modify the passed-in date": function(offset) {
+          var date = utc(2010, 11, 31, 23, 59, 59, 999);
+          offset(date, +1);
+          assert.deepEqual(date, utc(2010, 11, 31, 23, 59, 59, 999));
+        },
+        "does not round the passed-in-date": function(offset) {
+          assert.deepEqual(offset(utc(2010, 11, 31, 23, 59, 59, 999), +1), utc(2011, 00, 01, 00, 00, 00, 000));
+          assert.deepEqual(offset(utc(2010, 11, 31, 23, 59, 59, 456), -2), utc(2010, 11, 31, 23, 59, 59, 454));
+        },
+        "allows negative offsets": function(offset) {
+          assert.deepEqual(offset(utc(2010, 11, 31, 23, 59, 59, 999), -1), utc(2010, 11, 31, 23, 59, 59, 998));
+          assert.deepEqual(offset(utc(2011, 00, 01, 00, 00, 00, 000), -2), utc(2010, 11, 31, 23, 59, 59, 998));
+          assert.deepEqual(offset(utc(2011, 00, 01, 00, 00, 00, 000), -1), utc(2010, 11, 31, 23, 59, 59, 999));
+        },
+        "allows positive offsets": function(offset) {
+          assert.deepEqual(offset(utc(2010, 11, 31, 23, 59, 58, 998), +1), utc(2010, 11, 31, 23, 59, 58, 999));
+          assert.deepEqual(offset(utc(2010, 11, 31, 23, 59, 58, 998), +2), utc(2010, 11, 31, 23, 59, 59, 000));
+          assert.deepEqual(offset(utc(2010, 11, 31, 23, 59, 59, 999), +1), utc(2011, 00, 01, 00, 00, 00, 000));
+        },
+        "allows zero offset": function(offset) {
+          assert.deepEqual(offset(utc(2010, 11, 31, 23, 59, 59, 999), 0), utc(2010, 11, 31, 23, 59, 59, 999));
+          assert.deepEqual(offset(utc(2010, 11, 31, 23, 59, 58, 000), 0), utc(2010, 11, 31, 23, 59, 58, 000));
+        }
+      }
+    }
+  }
+});
+
+suite.export(module);

--- a/test/time/milliseconds-test.js
+++ b/test/time/milliseconds-test.js
@@ -1,0 +1,87 @@
+var vows = require("vows"),
+    load = require("../load"),
+    assert = require("../assert"),
+    time = require("./time"),
+    local = time.local,
+    utc = time.utc;
+
+var suite = vows.describe("d3.time.milliseconds");
+
+suite.addBatch({
+  "milliseconds": {
+    topic: load("time/millisecond").expression("d3.time.milliseconds"),
+    "returns milliseconds": function(range) {
+      assert.deepEqual(range(local(2010, 11, 31, 23, 59, 59, 998), local(2011, 0, 1, 0, 0, 0)), [
+        local(2010, 11, 31, 23, 59, 59, 998),
+        local(2010, 11, 31, 23, 59, 59, 999)
+      ]);
+    },
+    "has an inclusive lower bound": function(range) {
+      assert.deepEqual(range(local(2010, 11, 31, 23, 59, 59), local(2011, 0, 1, 0, 0, 2))[0], local(2010, 11, 31, 23, 59, 59));
+    },
+    "has an exclusive upper bound": function(range) {
+      assert.deepEqual(range(local(2010, 11, 31, 23, 59, 59), local(2011, 0, 1, 0, 0, 2))[2], local(2010, 11, 31, 23, 59, 59, 002));
+    },
+    "can skip milliseconds": function(range) {
+      assert.deepEqual(range(local(2011, 1, 1, 12, 0, 7,000), local(2011, 1, 1, 12, 0, 8,500), 500), [
+      local(2011, 1, 1, 12, 0, 7,000),
+      local(2011, 1, 1, 12, 0, 7,500),
+      local(2011, 1, 1, 12, 0, 8,000)
+      ]);
+    },
+    "observes start of daylight savings time": function(range) {
+      assert.deepEqual(range(utc(2011, 2, 13, 9, 59, 59, 000), utc(2011, 2, 13, 9, 59, 59, 003)), [
+      utc(2011, 2, 13, 9, 59, 59, 000),
+      utc(2011, 2, 13, 9, 59, 59, 001),
+      utc(2011, 2, 13, 9, 59, 59, 002)
+      ]);
+    },
+    "observes end of daylight savings time": function(range) {
+      assert.deepEqual(range(utc(2011, 10, 6, 8, 59, 59), utc(2011, 10, 6, 8, 59, 59, 003)), [
+      utc(2011, 10, 6, 8, 59, 59),
+      utc(2011, 10, 6, 8, 59, 59, 001),
+      utc(2011, 10, 6, 8, 59, 59, 002)
+      ]);
+    },
+    "UTC": {
+      topic: function(range) {
+        return range.utc;
+      },
+      "returns milliseconds": function(range) {
+        assert.deepEqual(range(utc(2010, 11, 31, 23, 59, 59,998), utc(2011, 0, 1, 0, 0, 0)), [
+          utc(2010, 11, 31, 23, 59, 59,998),
+          utc(2010, 11, 31, 23, 59, 59,999)
+        ]);
+      },
+      "has an inclusive lower bound": function(range) {
+        assert.deepEqual(range(utc(2010, 11, 31, 23, 59, 59), utc(2011, 0, 1, 0, 0, 2))[0], utc(2010, 11, 31, 23, 59, 59));
+      },
+      "has an exclusive upper bound": function(range) {
+        assert.deepEqual(range(utc(2010, 11, 31, 23, 59, 59, 000), utc(2010, 11, 31, 23, 59, 59, 003))[2], utc(2010, 11, 31, 23, 59, 59, 002));
+      },
+      "can skip milliseconds": function(range) {
+        assert.deepEqual(range(utc(2011, 1, 1, 12, 0, 7), utc(2011, 1, 1, 12, 0, 8, 500), 500), [
+        utc(2011, 1, 1, 12, 0, 7, 000),
+        utc(2011, 1, 1, 12, 0, 7, 500),
+        utc(2011, 1, 1, 12, 0, 8, 000)
+        ]);
+      },
+      "does not observe the start of daylight savings time": function(range) {
+        assert.deepEqual(range(utc(2011, 2, 13, 9, 59, 59), utc(2011, 2, 13, 9, 59, 59, 003)), [
+        utc(2011, 2, 13, 9, 59, 59, 000),
+        utc(2011, 2, 13, 9, 59, 59, 001),
+        utc(2011, 2, 13, 9, 59, 59, 002)
+        ]);
+      },
+      "does not observe the end of daylight savings time": function(range) {
+        assert.deepEqual(range(utc(2011, 10, 6, 8, 59, 59), utc(2011, 10, 6, 8, 59, 59, 003)), [
+        utc(2011, 10, 6, 8, 59, 59, 000),
+        utc(2011, 10, 6, 8, 59, 59, 001),
+        utc(2011, 10, 6, 8, 59, 59, 002)
+        ]);
+      }
+    }
+  }
+});
+
+suite.export(module);


### PR DESCRIPTION
This addition makes it very easy to have millisecond resolution ticks on the axis 

e.g.
```
maxBottomAxis.ticks(d3.time.milliseconds, 100).tickFormat(d3.time.format('%L'));
```
Issue #1529 does not provide quite the same functionality since it requires an explicit modification of the data.

```
d.time = new Date(+d.time * 1000);
```