### PR TITLE
Correct typos in d3-axis documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -99,9 +99,9 @@ Bin discrete samples into continuous, non-overlapping intervals.
 Human-readable reference marks for scales.
 
 * [d3.axisTop](https://github.com/d3/d3-axis/blob/master/README.md#axisTop) - create a new top-oriented axis generator.
-* [d3.axisRight](https://github.com/d3/d3-axis/blob/master/README.md#axisTight) - create a new right-oriented axis generator.
+* [d3.axisRight](https://github.com/d3/d3-axis/blob/master/README.md#axisRight) - create a new right-oriented axis generator.
 * [d3.axisBottom](https://github.com/d3/d3-axis/blob/master/README.md#axisBottom) - create a new bottom-oriented axis generator.
-* [d3.axisLeft](https://github.com/d3/d3-axis/blob/master/README.md#axisTeft) - create a new left-oriented axis generator.
+* [d3.axisLeft](https://github.com/d3/d3-axis/blob/master/README.md#axisLeft) - create a new left-oriented axis generator.
 * [*axis*](https://github.com/d3/d3-axis/blob/master/README.md#_axis) - generate an axis for the given selection.
 * [*axis*.scale](https://github.com/d3/d3-axis/blob/master/README.md#axis_scale) - set the scale.
 * [*axis*.ticks](https://github.com/d3/d3-axis/blob/master/README.md#axis_ticks) - customize how ticks are generated and formatted.


### PR DESCRIPTION
A few typos in the anchors for links in API.md:

"axisTight" -> "axisRight"
"axisTeft" -> "axisLeft"