### PR TITLE
Update desc of color.toString to match v4 functionality

### DIFF
--- a/API.md
+++ b/API.md
@@ -212,7 +212,7 @@ Color manipulation and color space conversion.
 * [*color*.brighter](https://github.com/d3/d3-color/blob/master/README.md#color_brighter) - create a brighter copy of this color.
 * [*color*.darker](https://github.com/d3/d3-color/blob/master/README.md#color_darker) - create a darker copy of this color.
 * [*color*.displayable](https://github.com/d3/d3-color/blob/master/README.md#color_displayable) - returns true if the color is displayable on standard hardware.
-* [*color*.toString](https://github.com/d3/d3-color/blob/master/README.md#color_toString) - format the color as an RGB hexadecimal string.
+* [*color*.toString](https://github.com/d3/d3-color/blob/master/README.md#color_toString) - returns string representation of rgb values.
 * [d3.rgb](https://github.com/d3/d3-color/blob/master/README.md#rgb) - create a new RGB color.
 * [d3.hsl](https://github.com/d3/d3-color/blob/master/README.md#hsl) - create a new HSL color.
 * [d3.lab](https://github.com/d3/d3-color/blob/master/README.md#lab) - create a new Lab color.


### PR DESCRIPTION
Super tiny change in documentation. 

Looks like the functionality of color.toString changed between v3 and v4. v3 returned hex representation and v4 returns string according to CSS spec. But, this description got missed in the md file. 

I wasn't sure if you'd prefer "returns string representation of rbg values" or "returns string according to CSS spec" or something else. Mostly just wanted to flag the need for this tweak in the documentation. 

thanks!