### PR TITLE
Support esm on node with conditional exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "jsdelivr": "dist/d3.min.js",
   "module": "index.js",
   "exports": {
-    "require": "./dist/d3.node.js",
-    "import": "./dist/d3.node.mjs"
+    "import": "./dist/d3.node.mjs",
+    "default": "./dist/d3.node.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
   "unpkg": "dist/d3.min.js",
   "jsdelivr": "dist/d3.min.js",
   "module": "index.js",
+  "exports": {
+    "require": "./dist/d3.node.js",
+    "import": "./dist/d3.node.mjs"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/d3/d3.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,5 +51,16 @@ export default [
       name: "d3"
     },
     onwarn
+  },
+  {
+    input: "index.js",
+    plugins: [
+      node(),
+    ],
+    output: {
+      file: "dist/d3.node.mjs",
+      format: "esm",
+    },
+    onwarn
   }
 ];


### PR DESCRIPTION
Since 13.6 node is able to load esm without the `--experimental-modules` flag, and since 13.7 node supports [conditional exports](https://nodejs.org/api/esm.html#esm_conditional_exports) unflagged as well.

While node can import cjs code from esm code just fine, currently only
```js
import d3 from 'd3';
```
is possible. If you try
```js
import { line } from 'd3';
```
you get
```
import { line } from 'd3';
         ^^^^
SyntaxError: The requested module 'd3' does not provide an export named 'line'
```
because Node doesn't support named exports from cjs modules.

I modified the build config to build an esm file for node as well and made sure node can find it using the conditional exports.

I am aware that the node version of d3 simply exports the individual `d3-*` modules whereas my build fully includes them in the code. I think that eventually the conditional exports should be used in each of the `d3-*` modules. I just wanted to add this as a PoC however to open up the discussion without going through all the work of implementing the conditional exports in each of the submodules.