### PR TITLE
Updated API Reference Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Resources
 
 * [Introduction](https://observablehq.com/@d3/learn-d3)
-* [API Reference](https://github.com/d3/d3/blob/master/API.md)
+* [API Reference](https://github.com/d3/d3/blob/main/API.md)
 * [Releases](https://github.com/d3/d3/releases)
 * [Examples](https://observablehq.com/@d3/gallery)
 * [Wiki](https://github.com/d3/d3/wiki)


### PR DESCRIPTION
The API Reference link at the top of README.md used "master" instead of "main". GitHub would redirect to the correct page, but with a warning message.