### PR TITLE
Repair package.json compatibility issues with react-native-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,11 @@
   "jsdelivr": "dist/d3.min.js",
   "unpkg": "dist/d3.min.js",
   "exports": {
-    "umd": "./dist/d3.min.js",
-    "default": "./src/index.js"
+    "./package.json": "./package.json",
+    ".": {
+      "umd": "./dist/d3.min.js",
+      "default": "./src/index.js"
+    }
   },
   "dependencies": {
     "d3-array": "3",


### PR DESCRIPTION
The react native CLI requires the `./package.json` key be filled in for libraries it uses. Without this being filled in, we have no way of starting the Bundling Server. Several libraries are updating to compensate for this (See: https://github.com/react-native-community/cli/issues/1168). 