### PR TITLE
Add short "D3 in React" section

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -256,3 +256,49 @@ import {mean, median} from "d3-array";
 ```
 
 TypeScript declarations are available via DefinitelyTyped.
+
+## D3 in React
+
+Most D3 modules (like d3-scale, d3-array, d3-color, d3-format, and d3-random) don’t interact with the DOM, so there is no difference when using them in React. You can use them in JSX to do purely declarative visualization, like this dot plot of a normal distribution:
+
+```jsx
+import {scaleLinear, extent} from "d3";
+
+function DotPlot({data, width}) {
+  const x = scaleLinear(extent(data), [5, width - 5]).nice(true);
+  return (
+    <svg width={width} height="4">
+      {data.map((d, i) => (
+        <circle key={i} cx={x(d)} cy="2" r="2" />
+      ))}
+    </svg>
+  );
+}
+```
+
+Some D3 modules (d3-selection, d3-transition, d3-axis, d3-brush, d3-zoom) do manipulate the DOM, which competes with React’s management of the DOM. In those cases, you can attach a ref to an element and pass it to D3 in a useEffect hook. For example, to add a D3 axis to the example above:
+
+```jsx
+import {scaleLinear, extent, select, axisBottom} from "d3";
+import {useRef, useEffect} from "react";
+
+function DotPlot({data, width}) {
+  const x = scaleLinear(extent(data), [5, width - 5]).nice(true);
+  const ref = useRef();
+  useEffect(() => {
+    if (!ref.current) return;
+    select(ref.current).append("g")
+        .attr("transform", "translate(0, 4)")
+        .call(axisBottom(x).ticks(5));
+  }, [x]);
+  return (
+    <svg width={width} height="20" ref={ref}>
+      {data.map((d, i) => (
+        <circle key={i} cx={x(d)} cy="2" r="2" />
+      ))}
+    </svg>
+  );
+}
+```
+
+For more guidance on specific scenarios using D3 in React, see [Amelia Wattenberger’s post](https://2019.wattenberger.com/blog/react-and-d3).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -259,7 +259,7 @@ TypeScript declarations are available via DefinitelyTyped.
 
 ## D3 in React
 
-Most D3 modules (like d3-scale, d3-array, d3-color, d3-format, and d3-random) don’t interact with the DOM, so there is no difference when using them in React. You can use them in JSX to do purely declarative visualization, like this dot plot of one-dimensional numeric data:
+Most D3 modules (including d3-scale, d3-array, d3-interpolate, and d3-format) don’t interact with the DOM, so there is no difference when using them in React. You can use them in JSX for purely declarative visualization, such as this one-dimensional dot plot of numbers:
 
 ```jsx
 import {scaleLinear, extent} from "d3";
@@ -276,7 +276,7 @@ function DotPlot({data, width}) {
 }
 ```
 
-Some D3 modules (d3-selection, d3-transition, d3-axis, d3-brush, d3-zoom) do manipulate the DOM, which competes with React’s management of the DOM. In those cases, you can attach a ref to an element and pass it to D3 in a useEffect hook. For example, to add an axis to the example above:
+Some D3 modules (d3-selection, d3-transition, d3-axis, d3-brush, d3-zoom) do manipulate the DOM, which competes with React’s virtual DOM. In those cases, you can attach a ref to an element and pass it to D3 in a useEffect hook. For example, to add an axis to the example above:
 
 ```jsx
 import {scaleLinear, extent, select, axisBottom} from "d3";
@@ -285,12 +285,14 @@ import {useRef, useEffect} from "react";
 function DotPlot({data, width}) {
   const x = scaleLinear(extent(data), [5, width - 5]).nice(true);
   const ref = useRef();
+
   useEffect(() => {
     const g = select(ref.current).append("g")
-        .attr("transform", "translate(0, 4)")
+        .attr("transform", "translate(0,4)")
         .call(axisBottom(x).ticks(5));
     return () => g.remove();
   }, [x]);
+
   return (
     <svg width={width} height="20" ref={ref}>
       {data.map((d, i) => (
@@ -301,4 +303,4 @@ function DotPlot({data, width}) {
 }
 ```
 
-For more guidance on specific scenarios using D3 in React, see [Amelia Wattenberger’s post](https://2019.wattenberger.com/blog/react-and-d3).
+For more guidance using D3 in React, see [Amelia Wattenberger’s post](https://2019.wattenberger.com/blog/react-and-d3).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -286,10 +286,10 @@ function DotPlot({data, width}) {
   const x = scaleLinear(extent(data), [5, width - 5]).nice(true);
   const ref = useRef();
   useEffect(() => {
-    if (!ref.current) return;
-    select(ref.current).append("g")
+    const g = select(ref.current).append("g")
         .attr("transform", "translate(0, 4)")
         .call(axisBottom(x).ticks(5));
+    return () => g.remove();
   }, [x]);
   return (
     <svg width={width} height="20" ref={ref}>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -259,7 +259,7 @@ TypeScript declarations are available via DefinitelyTyped.
 
 ## D3 in React
 
-Most D3 modules (like d3-scale, d3-array, d3-color, d3-format, and d3-random) don’t interact with the DOM, so there is no difference when using them in React. You can use them in JSX to do purely declarative visualization, like this dot plot of a normal distribution:
+Most D3 modules (like d3-scale, d3-array, d3-color, d3-format, and d3-random) don’t interact with the DOM, so there is no difference when using them in React. You can use them in JSX to do purely declarative visualization, like this dot plot of one-dimensional numeric data:
 
 ```jsx
 import {scaleLinear, extent} from "d3";
@@ -276,7 +276,7 @@ function DotPlot({data, width}) {
 }
 ```
 
-Some D3 modules (d3-selection, d3-transition, d3-axis, d3-brush, d3-zoom) do manipulate the DOM, which competes with React’s management of the DOM. In those cases, you can attach a ref to an element and pass it to D3 in a useEffect hook. For example, to add a D3 axis to the example above:
+Some D3 modules (d3-selection, d3-transition, d3-axis, d3-brush, d3-zoom) do manipulate the DOM, which competes with React’s management of the DOM. In those cases, you can attach a ref to an element and pass it to D3 in a useEffect hook. For example, to add an axis to the example above:
 
 ```jsx
 import {scaleLinear, extent, select, axisBottom} from "d3";


### PR DESCRIPTION
I know you removed the TODO but I was already trying to fill it in! I think just making the distinction of modules that touch the DOM and those that don't was super clarifying for me personally when I figured that out. And I always forget the most basic ref pattern (and still might've messed it up here). I don't think we should get into updating or interactivity or whatever, but I think just this much goes a long way toward demystifying (and showing just the most basic best practices).

<img width="420" alt="image" src="https://github.com/d3/d3/assets/841829/90d8463d-52ab-46f9-9b4e-54320dac6f7c">
