### PR TITLE
stop-gap css for maps in dark mode

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -67,3 +67,5 @@
 .vp-doc sub {
   line-height: 1;
 }
+
+:root.dark .dark-invert { filter: invert(0.883); }

--- a/docs/d3-geo/azimuthal.md
+++ b/docs/d3-geo/azimuthal.md
@@ -4,7 +4,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoAzimuthalEqualArea() {#geoAzimuthalEqualArea}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/azimuthalEqualArea.png" width="480" height="250">](https://observablehq.com/@d3/azimuthal-equal-area)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/azimuthalEqualArea.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/azimuthal-equal-area)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/azimuthalEqualArea.js) · The azimuthal equal-area projection.
 
@@ -12,7 +12,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoAzimuthalEquidistant() {#geoAzimuthalEquidistant}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/azimuthalEquidistant.png" width="480" height="250">](https://observablehq.com/@d3/azimuthal-equidistant)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/azimuthalEquidistant.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/azimuthal-equidistant)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/azimuthalEquidistant.js) · The azimuthal equidistant projection.
 
@@ -20,7 +20,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoGnomonic() {#geoGnomonic}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/gnomonic.png" width="480" height="250">](https://observablehq.com/@d3/gnomonic)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/gnomonic.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/gnomonic)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/gnomonic.js) · The gnomonic projection.
 
@@ -28,7 +28,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoOrthographic() {#geoOrthographic}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/orthographic.png" width="480" height="250">](https://observablehq.com/@d3/orthographic)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/orthographic.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/orthographic)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/orthographic.js) · The orthographic projection.
 
@@ -36,7 +36,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoStereographic() {#geoStereographic}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/stereographic.png" width="480" height="250">](https://observablehq.com/@d3/stereographic)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/stereographic.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/stereographic)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/stereographic.js) · The stereographic projection.
 

--- a/docs/d3-geo/conic.md
+++ b/docs/d3-geo/conic.md
@@ -8,7 +8,7 @@ Conic projections project the sphere onto a cone, and then unroll the cone onto 
 
 ## geoConicConformal() {#geoConicConformal}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/conicConformal.png" width="480" height="250">](https://observablehq.com/@d3/conic-conformal)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/conicConformal.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/conic-conformal)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/conicConformal.js) · The conic conformal projection. The parallels default to [30°, 30°] resulting in flat top.
 
@@ -16,7 +16,7 @@ Conic projections project the sphere onto a cone, and then unroll the cone onto 
 
 ## geoConicEqualArea() {#geoConicEqualArea}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/conicEqualArea.png" width="480" height="250">](https://observablehq.com/@d3/conic-equal-area)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/conicEqualArea.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/conic-equal-area)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/conicEqualArea.js) · The Albers’ equal-area conic projection.
 
@@ -24,7 +24,7 @@ Conic projections project the sphere onto a cone, and then unroll the cone onto 
 
 ## geoConicEquidistant() {#geoConicEquidistant}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/conicEquidistant.png" width="480" height="250">](https://observablehq.com/@d3/conic-equidistant)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/conicEquidistant.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/conic-equidistant)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/conicEquidistant.js) · The conic equidistant projection.
 
@@ -32,13 +32,13 @@ Conic projections project the sphere onto a cone, and then unroll the cone onto 
 
 ## geoAlbers() {#geoAlbers}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/albers.png" width="480" height="250">](https://observablehq.com/@d3/u-s-map)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/albers.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/u-s-map)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/albers.js) · The Albers’ equal area-conic projection. This is a U.S.-centric configuration of [geoConicEqualArea](#geoConicEqualArea).
 
 ## geoAlbersUsa() {#geoAlbersUsa}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/albersUsa.png" width="480" height="250">](https://observablehq.com/@d3/u-s-map)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/albersUsa.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/u-s-map)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/albersUsa.js) · This is a U.S.-centric composite projection of three [geoConicEqualArea](#geoConicEqualArea) projections: [geoAlbers](#geoAlbers) is used for the lower forty-eight states, and separate conic equal-area projections are used for Alaska and Hawaii. The scale for Alaska is diminished: it is projected at 0.35× its true relative area. See [Albers USA with Territories](https://www.npmjs.com/package/geo-albers-usa-territories) for an extension to all US territories, and [d3-composite-projections](http://geoexamples.com/d3-composite-projections/) for more examples.
 

--- a/docs/d3-geo/cylindrical.md
+++ b/docs/d3-geo/cylindrical.md
@@ -4,7 +4,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoEquirectangular() {#geoEquirectangular}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/equirectangular.png" width="480" height="250">](https://observablehq.com/@d3/equirectangular)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/equirectangular.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/equirectangular)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/equirectangular.js) · The equirectangular (plate carrée) projection.
 
@@ -12,7 +12,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoMercator() {#geoMercator}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/mercator.png" width="480" height="250">](https://observablehq.com/@d3/mercator)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/mercator.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/mercator)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/mercator.js) · The spherical Mercator projection. Defines a default [*projection*.clipExtent](./projection.md#projection_clipExtent) such that the world is projected to a square, clipped to approximately ±85° latitude.
 
@@ -20,7 +20,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoTransverseMercator() {#geoTransverseMercator}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/transverseMercator.png" width="480" height="250">](https://observablehq.com/@d3/transverse-mercator)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/transverseMercator.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/transverse-mercator)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/transverseMercator.js) · The transverse spherical Mercator projection. Defines a default [*projection*.clipExtent](./projection.md#projection_clipExtent) such that the world is projected to a square, clipped to approximately ±85° latitude.
 
@@ -28,7 +28,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoEqualEarth() {#geoEqualEarth}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/equalEarth.png" width="480" height="250">](https://observablehq.com/@d3/equal-earth)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/equalEarth.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/equal-earth)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/equalEarth.js) · The Equal Earth projection, an equal-area projection, by Bojan Šavrič _et al._, 2018.
 
@@ -36,7 +36,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoNaturalEarth1() {#geoNaturalEarth1}
 
-[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/naturalEarth1.png" width="480" height="250">](https://observablehq.com/@d3/natural-earth)
+[<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/naturalEarth1.png" width="480" height="250" class="dark-invert">](https://observablehq.com/@d3/natural-earth)
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/naturalEarth1.js) · The [Natural Earth projection](http://www.shadedrelief.com/NE_proj/) is a pseudocylindrical projection designed by Tom Patterson. It is neither conformal nor equal-area, but appealing to the eye for small-scale maps of the whole world.
 

--- a/docs/d3-geo/shape.md
+++ b/docs/d3-geo/shape.md
@@ -8,7 +8,7 @@ To generate a [great arc](https://en.wikipedia.org/wiki/Great-circle_distance) (
 
 ## geoGraticule() {#geoGraticule}
 
-<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/graticule.png" width="480" height="360">
+<img src="https://raw.githubusercontent.com/d3/d3-geo/main/img/graticule.png" width="480" height="360" class="dark-invert">
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/graticule.js) · Constructs a geometry generator for creating graticules: a uniform grid of [meridians](https://en.wikipedia.org/wiki/Meridian_\(geography\)) and [parallels](https://en.wikipedia.org/wiki/Circle_of_latitude) for showing projection distortion. The default graticule has meridians and parallels every 10° between ±80° latitude; for the polar regions, there are meridians every 90°.
 


### PR DESCRIPTION
note: on my computer I get #1e1e1e vs #1e1e20 for the actual background, and it's slightly noticeable. Still better than the white bg!

(next step will be to render them dynamically instead)

