### PR TITLE
State a general principle for which d3 modules compete with React

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -289,7 +289,7 @@ export default function LinePlot({
 ```
 :::
 
-Some D3 modules (including [d3-selection](./d3-selection.md), [d3-transition](./d3-transition.md), and [d3-axis](./d3-axis.md)) do manipulate the DOM, which competes with React’s virtual DOM. In those cases, you can attach a ref to an element and pass it to D3 in a useEffect hook. (See [sandbox](https://codesandbox.io/s/d3-react-useeffect-5lp0x6?file=/src/LinePlot.jsx).)
+D3 modules that operate on [selections](./d3-selection/selecting.md) (including [d3-selection](./d3-selection.md), [d3-transition](./d3-transition.md), and [d3-axis](./d3-axis.md)) do manipulate the DOM, which competes with React’s virtual DOM. In those cases, you can attach a ref to an element and pass it to D3 in a useEffect hook. (See [sandbox](https://codesandbox.io/s/d3-react-useeffect-5lp0x6?file=/src/LinePlot.jsx).)
 
 :::code-group
 ```jsx [LinePlot.jsx]


### PR DESCRIPTION
Not sure about the exact phrasing but I think something like this would be nice. It'd be overwhelming to list every module that touches the DOM, but it may be frustratingly vague to just say "most don't, some do". Is there a general principle by which the uninitiated reader might spot which do and don't? As a beginner programmer learning D3 I know I didn't have a good mental model of where the DOM fit in, but I think I'd at least be able to spot "does this take a selection".