### PR TITLE
fork intent on the gallery

### DIFF
--- a/docs/.vitepress/theme/gallery.data.js
+++ b/docs/.vitepress/theme/gallery.data.js
@@ -7,7 +7,13 @@ export default {
     const module = runtime.module((await import("https://api.observablehq.com/@d3/gallery.js?v=4")).default);
     const data = [];
     module.define("md", () => String.raw);
-    module.redefine("previews", () => (chunk) => data.push(...chunk));
+    module.redefine("previews", () => (chunk) => {
+      for (const { path, ...d } of chunk)
+        data.push({
+          ...d,
+          path: `${path}${path.includes("?") ? "&" : "?"}intent=fork`,
+        });
+    });
     const values = [];
     for (const output of module._resolve("previews")._outputs) {
       if (output._name) {


### PR DESCRIPTION
All the links in the [D3 Gallery](https://observablehq.com/@d3/gallery) have been cleaned. This adds the ?intent=fork parameter back.

cc: @ajangus
![sample](https://github.com/d3/d3/assets/7001/d018e51a-a92a-461d-a536-d6f41adadceb)
