### PR TITLE
Edit sentence to fix potential typo and for consistency

### DIFF
--- a/docs/d3-shape/arc.md
+++ b/docs/d3-shape/arc.md
@@ -168,7 +168,7 @@ The corner radius may not be larger than ([outerRadius](#arc_outerRadius) - [inn
 
 ## *arc*.startAngle(*angle*) {#arc_startAngle}
 
-[Source](https://github.com/d3/d3-shape/blob/main/src/arc.js) · If *angle* is specified, sets the start angle to the specified function or number in radius and returns this arc generator.
+[Source](https://github.com/d3/d3-shape/blob/main/src/arc.js) · If *angle* is specified, sets the start angle to the specified function or number and returns this arc generator.
 
 ```js
 const arc = d3.arc().startAngle(Math.PI / 4);


### PR DESCRIPTION
I believe that the word should have been "radians", not "radius". Instead of fixing this (potential) typo, however, maybe deleting this part of the sentence altogether is the better option? Deleting it makes the `arc.startAngle(angle)` description match the `arc.endAngle(angle)` description (which does not mention radius/radians in the corresponding sentence). Radians are addressed elsewhere, so mentioning them in the edited sentence is, perhaps, not necessary.