### PR TITLE
Update Slack invite links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -269,7 +269,7 @@ export default defineConfig({
       {icon: "github", link: "https://github.com/d3"},
       {icon: "twitter", link: "https://twitter.com/observablehq"},
       {icon: "mastodon", link: "https://vis.social/@observablehq"},
-      {icon: "slack", link: "https://join.slack.com/t/observable-community/shared_invite/zt-1x7gs4fck-UHhEFxUXKHVE8Qt3XmJCig"},
+      {icon: "slack", link: "https://observablehq.com/slack/join"},
       {icon: "linkedin", link: "https://www.linkedin.com/company/observable"},
       {icon: "youtube", link: "https://www.youtube.com/c/Observablehq"}
     ],

--- a/docs/.vitepress/theme/CustomFooter.vue
+++ b/docs/.vitepress/theme/CustomFooter.vue
@@ -14,7 +14,7 @@
           <div class="mb2 fw6 f14">Resources</div>
           <ul>
             <li class="mb2"><a target="_blank" href="https://talk.observablehq.com">Forum</a></li>
-            <li class="mb2"><a target="_blank" href="https://join.slack.com/t/observable-community/shared_invite/zt-1x7gs4fck-UHhEFxUXKHVE8Qt3XmJCig">Slack</a></li>
+            <li class="mb2"><a target="_blank" href="https://observablehq.com/slack/join">Slack</a></li>
             <li class="mb2"><a target="_blank" href="https://github.com/d3/d3/releases">Releases</a></li>
             <li class="mb2"><a target="_blank" href="https://observablehq.com/@observablehq/plot-twist-newsletter-signup">Newsletter</a></li>
           </ul>

--- a/docs/community.md
+++ b/docs/community.md
@@ -10,7 +10,7 @@ And of course, follow us on [Observable](https://observablehq.com/@observablehq?
 
 ## Getting help
 
-We recommend asking for help on the [Observable forum](https://talk.observablehq.com). Or if you prefer chat, join the [Observable community Slack](https://join.slack.com/t/observable-community/shared_invite/zt-1x7gs4fck-UHhEFxUXKHVE8Qt3XmJCig).
+We recommend asking for help on the [Observable forum](https://talk.observablehq.com). Or if you prefer chat, join the [Observable community Slack](https://observablehq.com/slack/join).
 
 We encourage you to share your work, no matter how messy, on [Observable](https://observablehq.com). Sharing live code is the easiest way to let people see what you see, and to debug your problem. Strive for a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) — it helps people hone in on your problem more quickly.
 
@@ -31,6 +31,6 @@ We’d love for you to join the community! Here are some ways to participate:
 
 * Upvote 👍 or comment on [GitHub issues](https://github.com/d3/d3/issues). We’d love your input on what to build next. If your desired feature isn’t already there, or if you’ve found a bug, file an issue and tell us about it.
 
-* Answer questions or participate in discussions on the [Observable forum](https://talk.observablehq.com/) and the [Observable community Slack](https://join.slack.com/t/observable-community/shared_invite/zt-1x7gs4fck-UHhEFxUXKHVE8Qt3XmJCig). You’ll help others, and might learn something yourself, too.
+* Answer questions or participate in discussions on the [Observable forum](https://talk.observablehq.com/) and the [Observable community Slack](https://observablehq.com/slack/join). You’ll help others, and might learn something yourself, too.
 
 Please help us maintain a positive environment for all by adhering to our [code of conduct](https://github.com/observablehq/.github/blob/master/CODE_OF_CONDUCT.md). Thank you!


### PR DESCRIPTION
Replaces temporary Slack invite links with a static redirect to the latest invite URL that can be updated independently.