### PR TITLE
boost range and extent in minisearch

### DIFF
--- a/docs/d3-array/summarize.md
+++ b/docs/d3-array/summarize.md
@@ -233,6 +233,8 @@ If the iterable contains no comparable values, returns [undefined, undefined].
 d3.extent(alphabet, (d) => d.doesnotexist) // [undefined, undefined]
 ```
 
+<!-- boost this document in minisearch --><span style="display:none">extent0 extent1 extent2 extent3 extent4 extent5 extent6 extent7 extent8 extent9</span>
+
 ## mode(*iterable*, *accessor*) {#mode}
 
 [Examples](https://observablehq.com/@d3/d3-mode) · [Source](https://github.com/d3/d3-array/blob/main/src/mode.js) · Returns the mode of the given *iterable*, *i.e.* the value which appears the most often. Ignores undefined, null and NaN values.

--- a/docs/d3-array/ticks.md
+++ b/docs/d3-array/ticks.md
@@ -88,3 +88,5 @@ d3.range(0, 1, 1 / 49) // 👎 returns 50 elements!
 ```js
 d3.range(49).map((d) => d / 49) // 👍 returns 49 elements
 ```
+
+<!-- boost this document in minisearch --><span style="display:none">range0 range1 range2 range3 range4 range5 range6 range7 range8 range9</span>


### PR DESCRIPTION
While I'd rather find a solution that makes minisearch more intelligent, a hacky solution is to add this to the end of the relevant sections.

closes #3786


cc: @mootari 