### PR TITLE
Clarify specifying the stroke attribute for symbolsStroke

### DIFF
--- a/docs/d3-shape/symbol.md
+++ b/docs/d3-shape/symbol.md
@@ -144,6 +144,7 @@ const symbolType = d3.scaleOrdinal(d3.symbolsFill);
 }' />
 
 [Source](https://github.com/d3/d3-shape/blob/main/src/symbol.js) · An array containing a set of symbol types designed for stroking: [circle](#symbolCircle), [plus](#symbolPlus), [times](#symbolTimes), [triangle2](#symbolTriangle2), [asterisk](#symbolAsterisk), [square2](#symbolSquare2), and [diamond2](#symbolDiamond2). Useful for a categorical shape encoding with an [ordinal scale](../d3-scale/ordinal.md).
+** Be aware that by default SVG paths stroke attribute is set to none. By not specifying the stroke the symbols will be **invisible**. **
 
 ```js
 const symbolType = d3.scaleOrdinal(d3.symbolsStroke);


### PR DESCRIPTION
While working with symbols I found out that it was unclear why my stroke symbols would not appear. I see in the example that the stroke attribute has to be explicitly passed. Adding a statement near the code would make sure it is clear.