### PR TITLE
Fix svg syntax for JSX code samples in getting-started with React

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -295,8 +295,8 @@ export default function LinePlot({
   const line = d3.line((d, i) => x(i), y);
   return (
     <svg width={width} height={height}>
-      <path fill="none" stroke="currentColor" stroke-width="1.5" d={line(data)} />
-      <g fill="white" stroke="currentColor" stroke-width="1.5">
+      <path fill="none" stroke="currentColor" strokeWidth="1.5" d={line(data)} />
+      <g fill="white" stroke="currentColor" strokeWidth="1.5">
         {data.map((d, i) => (<circle key={i} cx={x(i)} cy={y(d)} r="2.5" />))}
       </g>
     </svg>
@@ -334,8 +334,8 @@ export default function LinePlot({
     <svg width={width} height={height}>
       <g ref={gx} transform={`translate(0,${height - marginBottom})`} />
       <g ref={gy} transform={`translate(${marginLeft},0)`} />
-      <path fill="none" stroke="currentColor" stroke-width="1.5" d={line(data)} />
-      <g fill="white" stroke="currentColor" stroke-width="1.5">
+      <path fill="none" stroke="currentColor" strokeWidth="1.5" d={line(data)} />
+      <g fill="white" stroke="currentColor" strokeWidth="1.5">
         {data.map((d, i) => (<circle key={i} cx={x(i)} cy={y(d)} r="2.5" />))}
       </g>
     </svg>


### PR DESCRIPTION
JSX uses `camelCase` convention for props names. 
Updated `stroke-width` accordingly in React code samples.

[React support for SVG components](https://react.dev/reference/react-dom/components#all-svg-components)