### PR TITLE
Clarify doc for d3-selection/dispatch usage

### DIFF
--- a/docs/d3-selection/events.md
+++ b/docs/d3-selection/events.md
@@ -36,6 +36,8 @@ An optional *parameters* object may be specified to set additional properties of
 
 If *parameters* is a function, it is evaluated for each selected element, in order, being passed the current datum (*d*), the current index (*i*), and the current group (*nodes*), with *this* as the current DOM element (*nodes*[*i*]). It must return the parameters for the current element.
 
+Note: While you can bind an event listener to a `type.name` event type using `on()`, you cannot target a particular listener using `dispatch("type.name")`.  You must dispatch with just `type`.
+
 ## pointer(*event*, *target*) {#pointer}
 
 [Source](https://github.com/d3/d3-selection/blob/main/src/pointer.js) · Returns a two-element array of numbers [*x*, *y*] representing the coordinates of the specified *event* relative to the specified *target*.


### PR DESCRIPTION
Recently helped a colleague understand why `d3.dispatch()` wasn't working the way they anticipated.  Hopefully this clarifying note helps to alleviate other similar confusion of how to use dispatch in the future.

I'm open to direct revisions.  Thanks!