### PR TITLE
Clarifying the axis tick's default values

### DIFF
--- a/docs/d3-axis.md
+++ b/docs/d3-axis.md
@@ -213,12 +213,14 @@ If *format* is not specified, returns the current format function, which default
 
 ```js
 const axis = d3.axisBottom(x).tickSize(0);
+axis.tickSize() // 0
 ```
 
 If *size* is not specified, returns the current inner tick size, which defaults to 6.
 
 ```js
-axis.tickSize() // 0
+const axis = d3.axisBottom(x).tickSize(0);
+axis.tickSize() // 6
 ```
 
 ## *axis*.tickSizeInner(size) {#axis_tickSizeInner}
@@ -227,12 +229,14 @@ axis.tickSize() // 0
 
 ```js
 const axis = d3.axisBottom(x).tickSizeInner(0);
+axis.tickSizeInner() // 0
 ```
 
 If *size* is not specified, returns the current inner tick size, which defaults to 6.
 
 ```js
-axis.tickSizeInner() // 0
+const axis = d3.axisBottom(x);
+axis.tickSizeInner() // 6
 ```
 
 The inner tick size controls the length of the tick lines, offset from the native position of the axis.
@@ -243,12 +247,14 @@ The inner tick size controls the length of the tick lines, offset from the nativ
 
 ```js
 const axis = d3.axisBottom(x).tickSizeOuter(0);
+axis.tickSizeOuter() // 0
 ```
 
 If *size* is not specified, returns the current outer tick size, which defaults to 6.
 
 ```js
-axis.tickSizeOuter() // 0
+const axis = d3.axisBottom(x);
+axis.tickSizeOuter() // 6
 ```
 
 The outer tick size controls the length of the square ends of the domain path, offset from the native position of the axis. Thus, the “outer ticks” are not actually ticks but part of the domain path, and their position is determined by the associated scale’s domain extent. Thus, outer ticks may overlap with the first or last inner tick. An outer tick size of 0 suppresses the square ends of the domain path, instead producing a straight line.
@@ -259,12 +265,14 @@ The outer tick size controls the length of the square ends of the domain path, o
 
 ```js
 const axis = d3.axisBottom(x).tickPadding(0);
+axis.tickPadding() // 0
 ```
 
 If *padding* is not specified, returns the current padding which defaults to 3 pixels.
 
 ```js
-axis.tickPadding() // 0
+const axis = d3.axisBottom(x);
+axis.tickPadding() // 3
 ```
 
 ## *axis*.offset(offset) {#axis_offset}

--- a/docs/d3-axis.md
+++ b/docs/d3-axis.md
@@ -219,7 +219,7 @@ axis.tickSize() // 0
 If *size* is not specified, returns the current inner tick size, which defaults to 6.
 
 ```js
-const axis = d3.axisBottom(x).tickSize(0);
+const axis = d3.axisBottom(x);
 axis.tickSize() // 6
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -271,7 +271,7 @@ Alternatively you can install and import from D3 submodules:
 import {mean, median} from "d3-array";
 ```
 
-TypeScript declarations are available via DefinitelyTyped.
+TypeScript declarations are available via [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped).
 
 ## D3 in React
 


### PR DESCRIPTION
Hi, 

when I was first reading this part of the documentation, I felt a bit confused about the second paragraph, in which the text describes the default tick size as 6, but the code still uses the customized tick size and logs out a 0.
<img width="768" alt="original doc" src="https://github.com/d3/d3/assets/121406058/8de1d824-ee40-4d26-b819-adb76e05e8b3">

What I did is that I separated the customized tick size declaration from the default one to clarify the difference between the two settings.
<img width="889" alt="modified" src="https://github.com/d3/d3/assets/121406058/77123db7-7b6d-4565-9511-9e72bde11979">

Similar modifications were also made in the `axis.tickSizeInner`, `axis.tickSizeOuter`, and `axis.tickPadding` sections.

Thank you for considering this modification!