### PR TITLE
remove ?intent=fork

### DIFF
--- a/docs/components/ExampleAnimatedQuadtree.vue
+++ b/docs/components/ExampleAnimatedQuadtree.vue
@@ -53,6 +53,6 @@ export default {
 <template>
   <div style="margin: 1em 0;">
     <svg :width="width" :height="height" :viewBox="[0, 0, width, height].join(' ')" style="max-width: 100%; height: auto;"></svg>
-    <a href="https://observablehq.com/@d3/animated-quadtree?intent=fork" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
+    <a href="https://observablehq.com/@d3/animated-quadtree" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
   </div>
 </template>

--- a/docs/components/ExampleChord.vue
+++ b/docs/components/ExampleChord.vue
@@ -66,6 +66,6 @@ const chords = d3.chord()
         </path>
       </g>
     </svg>
-    <a href="https://observablehq.com/@d3/chord-diagram/2?intent=fork" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
+    <a href="https://observablehq.com/@d3/chord-diagram/2" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
   </div>
 </template>

--- a/docs/components/ExampleCollideForce.vue
+++ b/docs/components/ExampleCollideForce.vue
@@ -46,6 +46,6 @@ onUnmounted(() => {
 <template>
   <div style="margin: 1em 0;">
     <svg :width="width" :height="height" :viewBox="[-width / 2, -height / 2, width, height].join(' ')" fill="currentColor" style="overflow: visible; position: relative; z-index: 2; max-width: 100%; height: auto;" ref="container"></svg>
-    <a href="https://observablehq.com/@d3/collision-detection/2?intent=fork" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
+    <a href="https://observablehq.com/@d3/collision-detection/2" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
   </div>
 </template>

--- a/docs/components/ExampleDisjointForce.vue
+++ b/docs/components/ExampleDisjointForce.vue
@@ -85,6 +85,6 @@ onUnmounted(() => {
       <g ref="glink" stroke="currentColor" stroke-opacity="0.5"></g>
       <g ref="gnode" stroke="var(--vp-c-bg-alt)" stroke-width="1.5"></g>
     </svg>
-    <a href="https://observablehq.com/@d3/disjoint-force-directed-graph/2?intent=fork" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
+    <a href="https://observablehq.com/@d3/disjoint-force-directed-graph/2" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
   </div>
 </template>

--- a/docs/components/ExampleLinkForce.vue
+++ b/docs/components/ExampleLinkForce.vue
@@ -84,6 +84,6 @@ onUnmounted(() => {
 <template>
   <div style="margin: 1em 0;">
     <svg :width="width" :height="height" :viewBox="[-width / 2, -height / 2, width, height].join(' ')" fill="currentColor" style="overflow: visible; position: relative; z-index: 2; max-width: 100%; height: auto;" ref="container"></svg>
-    <a href="https://observablehq.com/@d3/force-directed-lattice?intent=fork" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
+    <a href="https://observablehq.com/@d3/force-directed-lattice" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
   </div>
 </template>

--- a/docs/d3-contour.md
+++ b/docs/d3-contour.md
@@ -23,7 +23,7 @@ import PlotRender from "./components/PlotRender.js";
       })
     ]
   }' />
-  <a href="https://observablehq.com/@d3/volcano-contours/2?intent=fork" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
+  <a href="https://observablehq.com/@d3/volcano-contours/2" style="font-size: smaller;" target="_blank">Fork ↗︎</a>
 </div>
 
 This module computes contour polygons by applying [marching squares](https://en.wikipedia.org/wiki/Marching_squares) to a rectangular grid of numeric values. For example, the contours above show the topography of [Maungawhau](https://en.wikipedia.org/wiki/Maungawhau_/_Mount_Eden).

--- a/docs/d3-drag.md
+++ b/docs/d3-drag.md
@@ -2,7 +2,7 @@
 
 [Examples](https://observablehq.com/collection/@d3/d3-drag) · [Drag-and-drop](https://en.wikipedia.org/wiki/Drag_and_drop) is a popular interaction method for manipulating spatial elements: move the pointer to an object, press and hold to grab it, “drag” the object to a new location, and release to “drop”. D3’s drag behavior provides a flexible abstraction for drag-and-drop. For example, you can drag nodes in a [force-directed graph](./d3-force.md):
 
-[<img alt="Force-Directed Graph" src="https://raw.githubusercontent.com/d3/d3-drag/master/img/force-graph.png" width="420" height="219">](https://observablehq.com/@d3/force-directed-graph/2?intent=fork)
+[<img alt="Force-Directed Graph" src="https://raw.githubusercontent.com/d3/d3-drag/master/img/force-graph.png" width="420" height="219">](https://observablehq.com/@d3/force-directed-graph/2)
 
 Or a simulation of colliding circles:
 

--- a/docs/d3-force.md
+++ b/docs/d3-force.md
@@ -8,9 +8,9 @@ import ExampleDisjointForce from "./components/ExampleDisjointForce.vue";
 
 <ExampleDisjointForce />
 
-This module implements a [velocity Verlet](https://en.wikipedia.org/wiki/Verlet_integration) numerical integrator for simulating physical forces on particles. Force simulations can be used to visualize [networks](https://observablehq.com/@d3/force-directed-graph/2?intent=fork) and [hierarchies](https://observablehq.com/@d3/force-directed-tree?intent=fork), and to resolve [collisions](./d3-force/collide.md) as in [bubble charts](http://www.nytimes.com/interactive/2012/09/06/us/politics/convention-word-counts.html).
+This module implements a [velocity Verlet](https://en.wikipedia.org/wiki/Verlet_integration) numerical integrator for simulating physical forces on particles. Force simulations can be used to visualize [networks](https://observablehq.com/@d3/force-directed-graph/2) and [hierarchies](https://observablehq.com/@d3/force-directed-tree), and to resolve [collisions](./d3-force/collide.md) as in [bubble charts](http://www.nytimes.com/interactive/2012/09/06/us/politics/convention-word-counts.html).
 
-<!-- [<img alt="Force-Directed Graph" src="https://raw.githubusercontent.com/d3/d3-force/master/img/graph.png" width="420" height="219">](https://observablehq.com/@d3/force-directed-graph/2?intent=fork) -->
+<!-- [<img alt="Force-Directed Graph" src="https://raw.githubusercontent.com/d3/d3-force/master/img/graph.png" width="420" height="219">](https://observablehq.com/@d3/force-directed-graph/2) -->
 
 <!-- [<img alt="Force-Directed Tree" src="https://raw.githubusercontent.com/d3/d3-force/master/img/tree.png" width="420" height="219">](https://observablehq.com/@d3/force-directed-tree) -->
 

--- a/docs/d3-force/link.md
+++ b/docs/d3-force/link.md
@@ -88,7 +88,7 @@ const links = [
 ];
 ```
 
-This is particularly useful when representing graphs in JSON, as JSON does not allow references. See [this example](https://observablehq.com/@d3/force-directed-graph/2?intent=fork).
+This is particularly useful when representing graphs in JSON, as JSON does not allow references. See [this example](https://observablehq.com/@d3/force-directed-graph/2).
 
 The id accessor is invoked for each node whenever the force is initialized, as when the [nodes](./simulation.md#simulation_nodes) or [links](#link_links) change, being passed the node and its zero-based index.
 

--- a/docs/d3-geo/azimuthal.md
+++ b/docs/d3-geo/azimuthal.md
@@ -14,7 +14,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoAzimuthalEqualArea() {#geoAzimuthalEqualArea}
 
-<a href="https://observablehq.com/@d3/azimuthal-equal-area?intent=fork" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoAzimuthalEqualArea().rotate([110, -40]).fitExtent([[1, 1], [width - 1, height - 1]], {type: "Sphere"}).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/azimuthal-equal-area" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoAzimuthalEqualArea().rotate([110, -40]).fitExtent([[1, 1], [width - 1, height - 1]], {type: "Sphere"}).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/azimuthalEqualArea.js) · The azimuthal equal-area projection.
 
@@ -22,7 +22,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoAzimuthalEquidistant() {#geoAzimuthalEquidistant}
 
-<a href="https://observablehq.com/@d3/azimuthal-equidistant?intent=fork" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoAzimuthalEquidistant().rotate([110, -40]).fitExtent([[1, 1], [width - 1, height - 1]], {type: "Sphere"}).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/azimuthal-equidistant" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoAzimuthalEquidistant().rotate([110, -40]).fitExtent([[1, 1], [width - 1, height - 1]], {type: "Sphere"}).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/azimuthalEquidistant.js) · The azimuthal equidistant projection.
 
@@ -30,7 +30,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoGnomonic() {#geoGnomonic}
 
-<a href="https://observablehq.com/@d3/gnomonic?intent=fork" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoGnomonic().scale(width / 6).translate([width / 2, height / 2]).clipAngle(74 - 1e-4).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/gnomonic" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoGnomonic().scale(width / 6).translate([width / 2, height / 2]).clipAngle(74 - 1e-4).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/gnomonic.js) · The gnomonic projection.
 
@@ -38,7 +38,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoOrthographic() {#geoOrthographic}
 
-<a href="https://observablehq.com/@d3/orthographic?intent=fork" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoOrthographic().rotate([110, -40]).fitExtent([[1, 1], [width - 1, height - 1]], {type: "Sphere"}).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/orthographic" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoOrthographic().rotate([110, -40]).fitExtent([[1, 1], [width - 1, height - 1]], {type: "Sphere"}).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/orthographic.js) · The orthographic projection.
 
@@ -46,7 +46,7 @@ Azimuthal projections project the sphere directly onto a plane.
 
 ## geoStereographic() {#geoStereographic}
 
-<a href="https://observablehq.com/@d3/stereographic?intent=fork" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoStereographic().scale(width / 4).translate([width / 2, height / 2]).rotate([-27, 0]).clipAngle(135 - 1e-4).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/stereographic" target="_blank" style="color: currentColor;"><WorldMap rotate :projection='d3.geoStereographic().scale(width / 4).translate([width / 2, height / 2]).rotate([-27, 0]).clipAngle(135 - 1e-4).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/stereographic.js) · The stereographic projection.
 

--- a/docs/d3-geo/conic.md
+++ b/docs/d3-geo/conic.md
@@ -19,7 +19,7 @@ Conic projections project the sphere onto a cone, and then unroll the cone onto 
 
 ## geoConicConformal() {#geoConicConformal}
 
-<a href="https://observablehq.com/@d3/conic-conformal?intent=fork" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :projection='d3.geoConicConformal().parallels([35, 65]).rotate([-20, 0]).scale(width * 0.55).center([0, 52]).translate([width / 2, height / 2]).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/conic-conformal" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :projection='d3.geoConicConformal().parallels([35, 65]).rotate([-20, 0]).scale(width * 0.55).center([0, 52]).translate([width / 2, height / 2]).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/conicConformal.js) · The conic conformal projection. The parallels default to [30°, 30°] resulting in flat top.
 
@@ -27,7 +27,7 @@ Conic projections project the sphere onto a cone, and then unroll the cone onto 
 
 ## geoConicEqualArea() {#geoConicEqualArea}
 
-<a href="https://observablehq.com/@d3/conic-conformal?intent=fork" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :projection='d3.geoConicEqualArea().parallels([35, 65]).rotate([-20, 0]).scale(width * 0.55).center([0, 52]).translate([width / 2, height / 2]).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/conic-conformal" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :projection='d3.geoConicEqualArea().parallels([35, 65]).rotate([-20, 0]).scale(width * 0.55).center([0, 52]).translate([width / 2, height / 2]).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/conicEqualArea.js) · The Albers’ equal-area conic projection.
 
@@ -35,7 +35,7 @@ Conic projections project the sphere onto a cone, and then unroll the cone onto 
 
 ## geoConicEquidistant() {#geoConicEquidistant}
 
-<a href="https://observablehq.com/@d3/conic-equidistant?intent=fork" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :projection='d3.geoConicEquidistant().parallels([35, 65]).rotate([-20, 0]).scale(width * 0.55).center([0, 52]).translate([width / 2, height / 2]).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/conic-equidistant" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :projection='d3.geoConicEquidistant().parallels([35, 65]).rotate([-20, 0]).scale(width * 0.55).center([0, 52]).translate([width / 2, height / 2]).clipExtent([[-1, -1], [width + 1, height + 1]]).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/conicEquidistant.js) · The conic equidistant projection.
 
@@ -43,13 +43,13 @@ Conic projections project the sphere onto a cone, and then unroll the cone onto 
 
 ## geoAlbers() {#geoAlbers}
 
-<a href="https://observablehq.com/@d3/u-s-map?intent=fork" target="_blank" style="color: currentColor;"><UsMap :projection='d3.geoAlbers().scale(1300 / 975 * width * 0.8).translate([width / 2, height / 2])' /></a>
+<a href="https://observablehq.com/@d3/u-s-map" target="_blank" style="color: currentColor;"><UsMap :projection='d3.geoAlbers().scale(1300 / 975 * width * 0.8).translate([width / 2, height / 2])' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/albers.js) · The Albers’ equal area-conic projection. This is a U.S.-centric configuration of [geoConicEqualArea](#geoConicEqualArea).
 
 ## geoAlbersUsa() {#geoAlbersUsa}
 
-<a href="https://observablehq.com/@d3/u-s-map?intent=fork" target="_blank" style="color: currentColor;"><UsMap :projection='d3.geoAlbersUsa().scale(1300 / 975 * width * 0.8).translate([width / 2, height / 2])' /></a>
+<a href="https://observablehq.com/@d3/u-s-map" target="_blank" style="color: currentColor;"><UsMap :projection='d3.geoAlbersUsa().scale(1300 / 975 * width * 0.8).translate([width / 2, height / 2])' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/albersUsa.js) · This is a U.S.-centric composite projection of three [geoConicEqualArea](#geoConicEqualArea) projections: [geoAlbers](#geoAlbers) is used for the lower forty-eight states, and separate conic equal-area projections are used for Alaska and Hawaii. The scale for Alaska is diminished: it is projected at 0.35× its true relative area. See [Albers USA with Territories](https://www.npmjs.com/package/geo-albers-usa-territories) for an extension to all US territories, and [d3-composite-projections](http://geoexamples.com/d3-composite-projections/) for more examples.
 

--- a/docs/d3-geo/cylindrical.md
+++ b/docs/d3-geo/cylindrical.md
@@ -14,7 +14,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoEquirectangular() {#geoEquirectangular}
 
-<a href="https://observablehq.com/@d3/equirectangular?intent=fork" target="_blank" style="color: currentColor;"><WorldMap :height="width / 2" :projection='d3.geoEquirectangular().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width / 2 - 1]], {type: "Sphere"}).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/equirectangular" target="_blank" style="color: currentColor;"><WorldMap :height="width / 2" :projection='d3.geoEquirectangular().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width / 2 - 1]], {type: "Sphere"}).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/equirectangular.js) · The equirectangular (plate carrée) projection.
 
@@ -22,7 +22,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoMercator() {#geoMercator}
 
-<a href="https://observablehq.com/@d3/mercator?intent=fork" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :height="width" :projection='d3.geoMercator().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width - 1]], {type: "Sphere"}).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/mercator" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :height="width" :projection='d3.geoMercator().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width - 1]], {type: "Sphere"}).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/mercator.js) · The spherical Mercator projection. Defines a default [*projection*.clipExtent](./projection.md#projection_clipExtent) such that the world is projected to a square, clipped to approximately ±85° latitude.
 
@@ -30,7 +30,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoTransverseMercator() {#geoTransverseMercator}
 
-<a href="https://observablehq.com/@d3/transverse-mercator?intent=fork" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :height="width" :projection='d3.geoTransverseMercator().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width - 1]], {type: "Sphere"}).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/transverse-mercator" target="_blank" style="color: currentColor;"><WorldMap resolution="50m" :height="width" :projection='d3.geoTransverseMercator().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width - 1]], {type: "Sphere"}).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/transverseMercator.js) · The transverse spherical Mercator projection. Defines a default [*projection*.clipExtent](./projection.md#projection_clipExtent) such that the world is projected to a square, clipped to approximately ±85° latitude.
 
@@ -38,7 +38,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoEqualEarth() {#geoEqualEarth}
 
-<a href="https://observablehq.com/@d3/equal-earth?intent=fork" target="_blank" style="color: currentColor;"><WorldMap :height="width * 0.49" :projection='d3.geoEqualEarth().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width * 0.49 - 1]], {type: "Sphere"}).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/equal-earth" target="_blank" style="color: currentColor;"><WorldMap :height="width * 0.49" :projection='d3.geoEqualEarth().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width * 0.49 - 1]], {type: "Sphere"}).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/equalEarth.js) · The Equal Earth projection, an equal-area projection, by Bojan Šavrič _et al._, 2018.
 
@@ -46,7 +46,7 @@ Cylindrical projections project the sphere onto a containing cylinder, and then 
 
 ## geoNaturalEarth1() {#geoNaturalEarth1}
 
-<a href="https://observablehq.com/@d3/natural-earth?intent=fork" target="_blank" style="color: currentColor;"><WorldMap :height="width * 0.5" :projection='d3.geoNaturalEarth1().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width * 0.5 - 1]], {type: "Sphere"}).precision(0.2)' /></a>
+<a href="https://observablehq.com/@d3/natural-earth" target="_blank" style="color: currentColor;"><WorldMap :height="width * 0.5" :projection='d3.geoNaturalEarth1().rotate([0, 0]).fitExtent([[1, 1], [width - 1, width * 0.5 - 1]], {type: "Sphere"}).precision(0.2)' /></a>
 
 [Source](https://github.com/d3/d3-geo/blob/main/src/projection/naturalEarth1.js) · The [Natural Earth projection](http://www.shadedrelief.com/NE_proj/) is a pseudocylindrical projection designed by Tom Patterson. It is neither conformal nor equal-area, but appealing to the eye for small-scale maps of the whole world.
 

--- a/docs/d3-hierarchy/partition.md
+++ b/docs/d3-hierarchy/partition.md
@@ -1,8 +1,8 @@
 # Partition {#Partition}
 
-[<img alt="Partition" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/partition.png">](https://observablehq.com/@d3/icicle/2?intent=fork)
+[<img alt="Partition" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/partition.png">](https://observablehq.com/@d3/icicle/2)
 
-[Examples](https://observablehq.com/@d3/icicle/2?intent=fork) · The partition layout produces adjacency diagrams: a space-filling variant of a [node-link tree diagram](./tree.md). Rather than drawing a link between parent and child in the hierarchy, nodes are drawn as solid areas (either arcs or rectangles), and their placement relative to other nodes reveals their position in the hierarchy. The size of the nodes encodes a quantitative dimension that would be difficult to show in a node-link diagram.
+[Examples](https://observablehq.com/@d3/icicle/2) · The partition layout produces adjacency diagrams: a space-filling variant of a [node-link tree diagram](./tree.md). Rather than drawing a link between parent and child in the hierarchy, nodes are drawn as solid areas (either arcs or rectangles), and their placement relative to other nodes reveals their position in the hierarchy. The size of the nodes encodes a quantitative dimension that would be difficult to show in a node-link diagram.
 
 ## partition() {#partition}
 

--- a/docs/d3-hierarchy/treemap.md
+++ b/docs/d3-hierarchy/treemap.md
@@ -1,8 +1,8 @@
 # Treemap {#Treemap}
 
-[<img alt="Treemap" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/treemap.png">](https://observablehq.com/@d3/treemap/2?intent=fork)
+[<img alt="Treemap" src="https://raw.githubusercontent.com/d3/d3-hierarchy/main/img/treemap.png">](https://observablehq.com/@d3/treemap/2)
 
-[Examples](https://observablehq.com/@d3/treemap/2?intent=fork) · Introduced by [Ben Shneiderman](http://www.cs.umd.edu/hcil/treemap-history/) in 1991, a **treemap** recursively subdivides area into rectangles according to each node’s associated value. D3’s treemap implementation supports an extensible [tiling method](#treemap_tile): the default [squarified](#treemapSquarify) method seeks to generate rectangles with a [golden](https://en.wikipedia.org/wiki/Golden_ratio) aspect ratio; this offers better readability and size estimation than [slice-and-dice](#treemapSliceDice), which simply alternates between horizontal and vertical subdivision by depth.
+[Examples](https://observablehq.com/@d3/treemap/2) · Introduced by [Ben Shneiderman](http://www.cs.umd.edu/hcil/treemap-history/) in 1991, a **treemap** recursively subdivides area into rectangles according to each node’s associated value. D3’s treemap implementation supports an extensible [tiling method](#treemap_tile): the default [squarified](#treemapSquarify) method seeks to generate rectangles with a [golden](https://en.wikipedia.org/wiki/Golden_ratio) aspect ratio; this offers better readability and size estimation than [slice-and-dice](#treemapSliceDice), which simply alternates between horizontal and vertical subdivision by depth.
 
 ## treemap() {#treemap}
 

--- a/docs/d3-scale/quantize.md
+++ b/docs/d3-scale/quantize.md
@@ -1,6 +1,6 @@
 # Quantize scales
 
-Quantize scales are similar to [linear scales](./linear.md), except they use a discrete rather than continuous range. The continuous input domain is divided into uniform segments based on the number of values in (*i.e.*, the cardinality of) the output range. Each range value *y* can be expressed as a quantized linear function of the domain value *x*: *y* = *m round(x)* + *b*. See [the quantized choropleth](https://observablehq.com/@d3/choropleth/2?intent=fork) for an example.
+Quantize scales are similar to [linear scales](./linear.md), except they use a discrete rather than continuous range. The continuous input domain is divided into uniform segments based on the number of values in (*i.e.*, the cardinality of) the output range. Each range value *y* can be expressed as a quantized linear function of the domain value *x*: *y* = *m round(x)* + *b*. See [the quantized choropleth](https://observablehq.com/@d3/choropleth/2) for an example.
 
 ## scaleQuantize(*domain*, *range*) {#scaleQuantize}
 

--- a/docs/d3-shape/arc.md
+++ b/docs/d3-shape/arc.md
@@ -11,7 +11,7 @@ const padRadius = ref(200);
 
 # Arcs
 
-The arc generator produces a [circular](https://en.wikipedia.org/wiki/Circular_sector) or [annular](https://en.wikipedia.org/wiki/Annulus_(mathematics)) sector, as in a [pie](https://observablehq.com/@d3/pie-chart/2?intent=fork) or [donut](https://observablehq.com/@d3/donut-chart/2?intent=fork) chart. Arcs are centered at the origin; use a [transform](http://www.w3.org/TR/SVG/coords.html#TransformAttribute) to move the arc to a different position.
+The arc generator produces a [circular](https://en.wikipedia.org/wiki/Circular_sector) or [annular](https://en.wikipedia.org/wiki/Annulus_(mathematics)) sector, as in a [pie](https://observablehq.com/@d3/pie-chart/2) or [donut](https://observablehq.com/@d3/donut-chart/2) chart. Arcs are centered at the origin; use a [transform](http://www.w3.org/TR/SVG/coords.html#TransformAttribute) to move the arc to a different position.
 
 ```js
 svg.append("path")

--- a/docs/d3-shape/area.md
+++ b/docs/d3-shape/area.md
@@ -3,7 +3,7 @@
 <!-- https://observablehq.com/@d3/stacked-area-chart -->
 <!-- https://observablehq.com/@d3/difference-chart -->
 
-[Examples](https://observablehq.com/@d3/area-chart/2?intent=fork) · The area generator produces an area defined by a *topline* and a *baseline* as in an area chart. Typically, the two lines share the same [*x*-values](#area_x) ([x0](#area_x0) = [x1](#area_x1)), differing only in *y*-value ([y0](#area_y0) and [y1](#area_y1)); most commonly, y0 is defined as a constant representing zero (the y scale’s output for zero). The *topline* is defined by x1 and y1 and is rendered first; the *baseline* is defined by x0 and y0 and is rendered second with the points in reverse order. With a [curveLinear](./curve.md#curveLinear) [curve](#area_curve), this produces a clockwise polygon. See also [radial areas](./radial-area.md).
+[Examples](https://observablehq.com/@d3/area-chart/2) · The area generator produces an area defined by a *topline* and a *baseline* as in an area chart. Typically, the two lines share the same [*x*-values](#area_x) ([x0](#area_x0) = [x1](#area_x1)), differing only in *y*-value ([y0](#area_y0) and [y1](#area_y1)); most commonly, y0 is defined as a constant representing zero (the y scale’s output for zero). The *topline* is defined by x1 and y1 and is rendered first; the *baseline* is defined by x0 and y0 and is rendered second with the points in reverse order. With a [curveLinear](./curve.md#curveLinear) [curve](#area_curve), this produces a clockwise polygon. See also [radial areas](./radial-area.md).
 
 ## area(*x*, *y0*, *y1*) {#area}
 
@@ -173,7 +173,7 @@ The default y1 accessor assumes that the input data are two-element arrays of nu
 
 ## *area*.defined(*defined*) {#area_defined}
 
-[Examples](https://observablehq.com/@d3/area-chart-missing-data/2?intent=fork) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js) · If *defined* is specified, sets the defined accessor to the specified function or boolean and returns this area generator.
+[Examples](https://observablehq.com/@d3/area-chart-missing-data/2) · [Source](https://github.com/d3/d3-shape/blob/main/src/area.js) · If *defined* is specified, sets the defined accessor to the specified function or boolean and returns this area generator.
 
 ```js
 const area = d3.area().defined((d) => !isNaN(d.Close));

--- a/docs/d3-shape/line.md
+++ b/docs/d3-shape/line.md
@@ -2,7 +2,7 @@
 
 <!-- https://observablehq.com/@d3/line-chart -->
 
-[Examples](https://observablehq.com/@d3/line-chart/2?intent=fork) · The line generator produces a [spline](https://en.wikipedia.org/wiki/Spline_(mathematics)) or [polyline](https://en.wikipedia.org/wiki/Polygonal_chain) as in a line chart. Lines also appear in many other visualization types, such as the links in [hierarchical edge bundling](https://observablehq.com/@d3/hierarchical-edge-bundling). See also [radial lines](./radial-line.md).
+[Examples](https://observablehq.com/@d3/line-chart/2) · The line generator produces a [spline](https://en.wikipedia.org/wiki/Spline_(mathematics)) or [polyline](https://en.wikipedia.org/wiki/Polygonal_chain) as in a line chart. Lines also appear in many other visualization types, such as the links in [hierarchical edge bundling](https://observablehq.com/@d3/hierarchical-edge-bundling). See also [radial lines](./radial-line.md).
 
 ## line(*x*, *y*) {#line}
 
@@ -88,7 +88,7 @@ The default y accessor assumes that the input data are two-element arrays of num
 
 ## *line*.defined(*defined*) {#line_defined}
 
-[Examples](https://observablehq.com/@d3/line-chart-missing-data/2?intent=fork) · [Source](https://github.com/d3/d3-shape/blob/main/src/line.js) · If *defined* is specified, sets the defined accessor to the specified function or boolean and returns this line generator.
+[Examples](https://observablehq.com/@d3/line-chart-missing-data/2) · [Source](https://github.com/d3/d3-shape/blob/main/src/line.js) · If *defined* is specified, sets the defined accessor to the specified function or boolean and returns this line generator.
 
 ```js
 const line = d3.line().defined((d) => !isNaN(d.Close));

--- a/docs/d3-shape/pie.md
+++ b/docs/d3-shape/pie.md
@@ -9,7 +9,7 @@ const padAngle = ref(0.03);
 
 # Pies
 
-[Examples](https://observablehq.com/@d3/donut-chart/2?intent=fork) · The pie generator computes the necessary angles to represent a tabular dataset as a pie or donut chart; these angles can then be passed to an [arc generator](./arc.md). (The pie generator does not produce a shape directly.)
+[Examples](https://observablehq.com/@d3/donut-chart/2) · The pie generator computes the necessary angles to represent a tabular dataset as a pie or donut chart; these angles can then be passed to an [arc generator](./arc.md). (The pie generator does not produce a shape directly.)
 
 ## pie() {#pie}
 

--- a/docs/d3-shape/stack.md
+++ b/docs/d3-shape/stack.md
@@ -17,7 +17,7 @@ onMounted(() => {
 
 <!-- https://observablehq.com/@mbostock/streamgraph-transitions -->
 
-[Examples](https://observablehq.com/@d3/stacked-bar-chart/2?intent=fork) · Stacking converts lengths into contiguous position intervals. For example, a bar chart of monthly sales might be broken down into a multi-series bar chart by category, stacking bars vertically and applying a categorical color encoding. Stacked charts can show overall value and per-category value simultaneously; however, it is typically harder to compare across categories as only the bottom layer of the stack is aligned. So, chose the [stack order](#stack_order) carefully, and consider a [streamgraph](#stackOffsetWiggle). (See also [grouped charts](https://observablehq.com/@d3/grouped-bar-chart/2?intent=fork).)
+[Examples](https://observablehq.com/@d3/stacked-bar-chart/2) · Stacking converts lengths into contiguous position intervals. For example, a bar chart of monthly sales might be broken down into a multi-series bar chart by category, stacking bars vertically and applying a categorical color encoding. Stacked charts can show overall value and per-category value simultaneously; however, it is typically harder to compare across categories as only the bottom layer of the stack is aligned. So, chose the [stack order](#stack_order) carefully, and consider a [streamgraph](#stackOffsetWiggle). (See also [grouped charts](https://observablehq.com/@d3/grouped-bar-chart/2).)
 
 Like the [pie generator](./pie.md), the stack generator does not produce a shape directly. Instead it computes positions which you can then pass to an [area generator](./area.md) or use directly, say to position bars.
 
@@ -373,7 +373,7 @@ const stack = d3.stack().offset(d3.stackOffsetExpand);
 const stack = d3.stack().offset(d3.stackOffsetDiverging);
 ```
 
-[Source](https://github.com/d3/d3-shape/blob/main/src/offset/diverging.js) · Positive values are stacked above zero, negative values are [stacked below zero](https://observablehq.com/@d3/diverging-stacked-bar-chart/2?intent=fork), and zero values are stacked at zero.
+[Source](https://github.com/d3/d3-shape/blob/main/src/offset/diverging.js) · Positive values are stacked above zero, negative values are [stacked below zero](https://observablehq.com/@d3/diverging-stacked-bar-chart/2), and zero values are stacked at zero.
 
 ### stackOffsetNone(*series*, *order*) {#stackOffsetNone}
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,11 +56,11 @@ The fastest way to get started (and get help) with D3 is on [Observable](https:/
 
 As a more complete example, try one of these starter templates:
 
-* [Area chart](https://observablehq.com/@d3/area-chart/2?intent=fork)
-* [Bar chart](https://observablehq.com/@d3/bar-chart/2?intent=fork)
-* [Donut chart](https://observablehq.com/@d3/donut-chart/2?intent=fork)
-* [Histogram](https://observablehq.com/@d3/histogram/2?intent=fork)
-* [Line chart](https://observablehq.com/@d3/line-chart/2?intent=fork)
+* [Area chart](https://observablehq.com/@d3/area-chart/2)
+* [Bar chart](https://observablehq.com/@d3/bar-chart/2)
+* [Donut chart](https://observablehq.com/@d3/donut-chart/2)
+* [Histogram](https://observablehq.com/@d3/histogram/2)
+* [Line chart](https://observablehq.com/@d3/line-chart/2)
 
 See the [D3 gallery](https://observablehq.com/@d3/gallery) for more forkable examples.
 


### PR DESCRIPTION
Removes the `?intent=fork`, suppressing the green fixed banner at the top of notebooks to give a cleaner presentation of the notebook.