### PR TITLE
add rel external to observablehq links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
           {text: "What is D3?", link: "/what-is-d3"},
           {text: "Getting started", link: "/getting-started"},
           {text: "API index", link: "/api"},
-          {text: "Examples", link: "https://observablehq.com/@d3/gallery?utm_source=d3js-org&utm_medium=page-nav&utm_campaign=try-observable"}
+          {text: "Examples", link: "https://observablehq.com/@d3/gallery?utm_source=d3js-org&utm_medium=page-nav&utm_campaign=try-observable", rel: "external"}
         ]
       },
       {

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ hero:
     - theme: alt
       text: Examples
       link: https://observablehq.com/@d3/gallery?utm_source=d3js-org&utm_medium=hero&utm_campaign=try-observable
+      rel: external
 
 features:
   - title: Selections and transitions


### PR DESCRIPTION
In order for us to track referrals from d3js.org to observablehq.com, we need to add rel = "external" to the links from Vitepress's buttons and navigation.