### PR TITLE
docs: describe property as optional in d3-format locale

### DIFF
--- a/docs/d3-format.md
+++ b/docs/d3-format.md
@@ -107,10 +107,10 @@ const enUs = d3.formatLocale({
 
 [Source](https://github.com/d3/d3-format/blob/main/src/locale.js) · Returns a *locale* object for the specified *definition* with [*locale*.format](#locale_format) and [*locale*.formatPrefix](#locale_formatPrefix) methods. The *definition* must include the following properties:
 
-* `decimal` - the decimal point (e.g., `"."`).
 * `thousands` - the group separator (e.g., `","`).
 * `grouping` - the array of group sizes (e.g., `[3]`), cycled as needed.
 * `currency` - the currency prefix and suffix (e.g., `["$", ""]`).
+* `decimal` - optional; the decimal point (e.g., `"."`).
 * `numerals` - optional; an array of ten strings to replace the numerals 0-9.
 * `percent` - optional; the percent sign (defaults to `"%"`).
 * `minus` - optional; the minus sign (defaults to `"−"`).


### PR DESCRIPTION
This PR updates the docs for the package `d3-format`

As per the [source code](https://github.com/d3/d3-format/blob/f3cb31091df80a08f25afd4a7af2dcb3a6cd5eef/src/locale.js#L17) and [example usage](https://d3js.org/d3-format#formatLocale), `decimal` is also an optional attribute for the locale config. This PR updates the docs to reflect that.

