### PR TITLE
Update outdated examples link in cluster.md

### DIFF
--- a/docs/d3-hierarchy/cluster.md
+++ b/docs/d3-hierarchy/cluster.md
@@ -26,7 +26,7 @@ const gods = [
   ]
 }' />
 
-[Examples](https://observablehq.com/@d3/cluster-dendrogram) · The cluster layout produces [dendrograms](http://en.wikipedia.org/wiki/Dendrogram): node-link diagrams that place leaf nodes of the tree at the same depth. Dendrograms are typically less compact than [tidy trees](./tree.md), but are useful when all the leaves should be at the same level, such as for hierarchical clustering or [phylogenetic tree diagrams](https://observablehq.com/@d3/tree-of-life).
+[Examples](https://observablehq.com/@d3/cluster/2) · The cluster layout produces [dendrograms](http://en.wikipedia.org/wiki/Dendrogram): node-link diagrams that place leaf nodes of the tree at the same depth. Dendrograms are typically less compact than [tidy trees](./tree.md), but are useful when all the leaves should be at the same level, such as for hierarchical clustering or [phylogenetic tree diagrams](https://observablehq.com/@d3/tree-of-life).
 
 ## cluster() {#cluster}
 


### PR DESCRIPTION
The examples link on the [Cluster documentation page](https://d3js.org/d3-hierarchy/cluster) currently links to an Observable notebook that is marked as deprecated and unlisted. This pull request updates the link to the new Observable notebook with the Cluster tree examples.

Current, deprecated link: https://observablehq.com/@d3/cluster-dendrogram which is redirecting to https://observablehq.com/@d3/cluster
New link: https://observablehq.com/@d3/cluster/2