### PR TITLE
fix: support links on d3js.org are outdated

### DIFF
--- a/docs/.vitepress/theme/CustomFooter.vue
+++ b/docs/.vitepress/theme/CustomFooter.vue
@@ -15,6 +15,7 @@
           <ul>
             <li class="mb2"><a target="_blank" href="https://talk.observablehq.com">Forum</a></li>
             <li class="mb2"><a target="_blank" href="https://observablehq.com/slack/join">Slack</a></li>
+            <li class="mb2"><a target="_blank" href="https://github.com/d3/d3/discussions">Discussions</a></li>
             <li class="mb2"><a target="_blank" href="https://github.com/d3/d3/releases">Releases</a></li>
           </ul>
         </div>

--- a/docs/community.md
+++ b/docs/community.md
@@ -10,7 +10,7 @@ And of course, follow us on [Observable](https://observablehq.com/@observablehq?
 
 ## Getting help
 
-We recommend asking for help on the [Observable forum](https://talk.observablehq.com). Or if you prefer chat, join the [Observable community Slack](https://observablehq.com/slack/join).
+We recommend asking for help in our [GitHub Discussions](https://github.com/d3/d3/discussions). This is the preferred platform for support requests and community engagement.
 
 We encourage you to share your work, no matter how messy, on [Observable](https://observablehq.com). Sharing live code is the easiest way to let people see what you see, and to debug your problem. Strive for a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) — it helps people hone in on your problem more quickly.
 


### PR DESCRIPTION
This PR addresses issue [#4007](https://github.com/d3/d3/issues/4007) by updating the outdated support links on d3js.org. These updates ensure that users are directed to the current and preferred support channel, improving the accuracy of the documentation and user experience. @Fil @mbostock 