### PR TITLE
Added d3-tile and d3-hexbin to default bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "d3-force": "^3.0.0",
     "d3-format": "^3.1.0",
     "d3-geo": "^3.1.1",
+    "d3-hexbin": "^0.2.2",
     "d3-hierarchy": "^3.1.2",
     "d3-interpolate": "^3.0.1",
     "d3-path": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "d3-polygon": "^3.0.1",
     "d3-quadtree": "^3.0.1",
     "d3-random": "^3.0.1",
+    "d3-tile": "^1.0.0",
     "d3-scale": "^4.0.2",
     "d3-scale-chromatic": "^3.1.0",
     "d3-selection": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export * from "d3-fetch";
 export * from "d3-force";
 export * from "d3-format";
 export * from "d3-geo";
+export * from "d3-hexbin";
 export * from "d3-hierarchy";
 export * from "d3-interpolate";
 export * from "d3-path";

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ export * from "d3-path";
 export * from "d3-polygon";
 export * from "d3-quadtree";
 export * from "d3-random";
+export * from "d3-tile";
 export * from "d3-scale";
 export * from "d3-scale-chromatic";
 export * from "d3-selection";


### PR DESCRIPTION
Fixes #3683 #3684 
This PR adds d3-tile and d3-hexbin to the D3 default bundle.